### PR TITLE
feat(examples): enrich RawHex logs with bitfield schema summaries

### DIFF
--- a/examples/CommLib.Examples.WinUI/Models/DeviceLabAppSettings.cs
+++ b/examples/CommLib.Examples.WinUI/Models/DeviceLabAppSettings.cs
@@ -1,4 +1,5 @@
 using CommLib.Domain.Configuration;
+using CommLib.Domain.Messaging;
 
 namespace CommLib.Examples.WinUI.Models;
 
@@ -40,6 +41,8 @@ public sealed class SessionAppSettings
 public sealed class MessageComposerAppSettings
 {
     public string SerializerType { get; set; } = SerializerTypes.AutoBinary;
+
+    public BitFieldPayloadSchema? BitFieldSchema { get; set; }
 
     public string OutboundMessageId { get; set; } = "100";
 

--- a/examples/CommLib.Examples.WinUI/README.md
+++ b/examples/CommLib.Examples.WinUI/README.md
@@ -30,6 +30,7 @@ dotnet run --project examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.cspr
 
 - The peer device or test server must speak the same `LengthPrefixed + serializer` combination currently selected in the app.
 - `AutoBinary` keeps the existing text-body example format, while `RawHex` sends whitespace-tolerant hexadecimal byte pairs as the raw payload.
+- `RawHex` can now also load an optional `messageComposer.bitFieldSchema` from `appsettings.json`; when present, the live log appends decoded field summaries for inbound/outbound binary payloads. There is still no in-app schema editor, so this schema is currently JSON-managed only.
 - TCP and UDP expect a reachable remote endpoint.
 - Multicast receive/send requires the same group and port on both sides.
 - Serial requires a real COM port, a paired virtual port, or hardware loopback wiring.
@@ -38,3 +39,41 @@ dotnet run --project examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.cspr
 - The in-app mock peer path covers TCP, UDP, and Multicast on loopback; Serial still stays external because it needs a paired COM environment.
 - The sample now defaults to `win-x64` again because the current branch state no longer reproduces the earlier local `Microsoft.UI.Xaml.dll` startup fault; `-r win-x86` remains available if you need to compare runtimes.
 - The default `appsettings.json` is copied to the output folder on build and then reused as the runtime settings file.
+
+## RawHex Schema Example
+
+Use a `RawHex` serializer plus `messageComposer.bitFieldSchema` when you want the live log to append decoded field summaries for binary payloads:
+
+```json
+{
+  "messageComposer": {
+    "serializerType": "RawHex",
+    "bitFieldSchema": {
+      "payloadLengthBytes": 4,
+      "fields": [
+        {
+          "name": "prefix",
+          "bitOffset": 0,
+          "bitLength": 8
+        },
+        {
+          "name": "register",
+          "bitOffset": 8,
+          "bitLength": 16,
+          "endianness": "BigEndian"
+        },
+        {
+          "name": "tail",
+          "bitOffset": 24,
+          "bitLength": 8
+        }
+      ]
+    },
+    "outboundMessageId": "100",
+    "outboundBody": "AA 12 34 7F"
+  }
+}
+```
+
+- The schema is used for log enrichment only in this slice; it does not add an in-app schema editor or change the transport/protocol boundary.
+- `BigEndian` is currently supported only for byte-aligned multi-byte fields whose lengths are whole-byte multiples.

--- a/examples/CommLib.Examples.WinUI/Services/AppLocalizer.cs
+++ b/examples/CommLib.Examples.WinUI/Services/AppLocalizer.cs
@@ -125,6 +125,8 @@ public sealed class AppLocalizer : IAppLocalizer
         ["session.log.outbound.message"] = "id={0}, body=\"{1}\"",
         ["session.log.inbound.title"] = "Inbound message",
         ["session.log.inbound.message"] = "id={0}, body=\"{1}\"",
+        ["session.payload.fieldsSuffix"] = "fields[{0}]",
+        ["session.payload.schemaErrorSuffix"] = "schema decode failed: {0}",
         ["session.log.receiveLoopStopped.title"] = "Receive loop stopped",
         ["session.event.connectAttempt.title"] = "Connect attempt",
         ["session.event.connectAttempt.message"] = "{0} ({1}/{2})",
@@ -275,7 +277,9 @@ public sealed class AppLocalizer : IAppLocalizer
         ["transport.detail.udp"] = "UDP 로컬={0}, 원격={1}:{2}",
         ["transport.detail.multicast"] = "멀티캐스트 {0}:{1}",
         ["transport.detail.serial"] = "시리얼 {0} @ {1}",
-        ["transport.detail.generic"] = "전송 {0}"
+        ["transport.detail.generic"] = "전송 {0}",
+        ["session.payload.fieldsSuffix"] = "\uD544\uB4DC[{0}]",
+        ["session.payload.schemaErrorSuffix"] = "\uC2A4\uD0A4\uB9C8 \uD574\uC11D \uC2E4\uD328: {0}"
     };
 
     private AppLanguageMode _currentLanguage;

--- a/examples/CommLib.Examples.WinUI/Services/DeviceLabSessionService.cs
+++ b/examples/CommLib.Examples.WinUI/Services/DeviceLabSessionService.cs
@@ -22,6 +22,7 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
     private CancellationTokenSource? _receiveLoopCts;
     private Task? _receiveLoopTask;
     private string? _connectedDeviceId;
+    private BitFieldPayloadSchema? _activeBitFieldSchema;
     private bool _hasState;
     private bool _isConnectedState;
     private string _statusTextKey = "session.state.disconnected";
@@ -75,6 +76,7 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
 
             _manager = manager;
             _connectedDeviceId = profile.DeviceId;
+            _activeBitFieldSchema = profile.Serializer.BitFieldSchema;
             _receiveLoopCts = new CancellationTokenSource();
             // 실제 수신은 백그라운드 루프가 담당하고, 결과만 log/state 이벤트로 ViewModel에 흘려보낸다.
             _receiveLoopTask = Task.Run(() => ReceiveLoopAsync(profile.DeviceId, _receiveLoopCts.Token));
@@ -133,7 +135,7 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
             }
 
             await _manager.SendAsync(_connectedDeviceId, message, cancellationToken).ConfigureAwait(false);
-            var body = MessagePayloadFormatter.FormatBody(message);
+            var body = FormatMessageBodyForLog(message);
             EmitLocalizedLog(
                 LogSeverity.Info,
                 "session.log.outbound.title",
@@ -176,7 +178,7 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
                 }
 
                 var message = await manager.ReceiveAsync(deviceId, cancellationToken).ConfigureAwait(false);
-                var body = MessagePayloadFormatter.FormatBody(message);
+                var body = FormatMessageBodyForLog(message);
                 EmitLocalizedLog(
                     LogSeverity.Success,
                     "session.log.inbound.title",
@@ -250,11 +252,13 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
             {
                 _manager = null;
                 _connectedDeviceId = null;
+                _activeBitFieldSchema = null;
             }
         }
         else
         {
             _connectedDeviceId = null;
+            _activeBitFieldSchema = null;
         }
 
         if (emitOfflineState)
@@ -276,6 +280,23 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
     private void EmitLocalizedLog(LogSeverity severity, string titleKey, string messageKey, params object?[] args)
     {
         EmitLog(severity, _localizer.Get(titleKey), _localizer.Format(messageKey, args));
+    }
+
+    private string FormatMessageBodyForLog(IMessage message)
+    {
+        var body = MessagePayloadFormatter.FormatBody(message);
+
+        if (MessagePayloadFormatter.TryFormatBitFieldSummary(message, _activeBitFieldSchema, out var summary, out var error))
+        {
+            return AppendPayloadSuffix(body, _localizer.Format("session.payload.fieldsSuffix", summary));
+        }
+
+        if (!string.IsNullOrWhiteSpace(error))
+        {
+            return AppendPayloadSuffix(body, _localizer.Format("session.payload.schemaErrorSuffix", error));
+        }
+
+        return body;
     }
 
     private void SetState(
@@ -321,6 +342,18 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
             SerialTransportOptions serial => ("transport.detail.serial", [serial.PortName ?? string.Empty, serial.BaudRate]),
             _ => ("transport.detail.generic", [transport.Type ?? string.Empty])
         };
+    }
+
+    private static string AppendPayloadSuffix(string body, string suffix)
+    {
+        if (string.IsNullOrWhiteSpace(suffix))
+        {
+            return body;
+        }
+
+        return string.IsNullOrEmpty(body)
+            ? suffix
+            : $"{body} | {suffix}";
     }
 
     private sealed class SessionConnectionEventSink(DeviceLabSessionService owner) : IConnectionEventSink

--- a/examples/CommLib.Examples.WinUI/ViewModels/DeviceLabSettingsViewModel.cs
+++ b/examples/CommLib.Examples.WinUI/ViewModels/DeviceLabSettingsViewModel.cs
@@ -1,4 +1,5 @@
 using CommLib.Domain.Configuration;
+using CommLib.Domain.Messaging;
 using CommLib.Examples.WinUI.Models;
 using CommLib.Examples.WinUI.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -14,6 +15,7 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
     private string _maxPendingRequests = "8";
     private string _outboundMessageId = "100";
     private string _outboundBody = "hello from the mvvm winui lab";
+    private BitFieldPayloadSchema? _bitFieldSchema;
     private LanguageChoiceViewModel _selectedLanguage = null!;
     private SerializerChoiceViewModel _selectedSerializer = null!;
     private TransportChoiceViewModel _selectedTransport = null!;
@@ -107,6 +109,12 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
         set => SetProperty(ref _outboundBody, value);
     }
 
+    public BitFieldPayloadSchema? BitFieldSchema
+    {
+        get => _bitFieldSchema;
+        set => SetProperty(ref _bitFieldSchema, value);
+    }
+
     public LanguageChoiceViewModel SelectedLanguage
     {
         get => _selectedLanguage;
@@ -190,6 +198,7 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
             MessageComposer = new MessageComposerAppSettings
             {
                 SerializerType = SelectedSerializer.Type,
+                BitFieldSchema = BitFieldSchema,
                 OutboundMessageId = OutboundMessageId,
                 OutboundBody = OutboundBody
             },
@@ -240,6 +249,7 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
         DefaultTimeoutMs = settings.Session.DefaultTimeoutMs;
         MaxPendingRequests = settings.Session.MaxPendingRequests;
         SelectedSerializer = ResolveSerializerChoice(settings.MessageComposer.SerializerType);
+        BitFieldSchema = settings.MessageComposer.BitFieldSchema;
         OutboundMessageId = settings.MessageComposer.OutboundMessageId;
         OutboundBody = settings.MessageComposer.OutboundBody;
 

--- a/examples/CommLib.Examples.WinUI/appsettings.json
+++ b/examples/CommLib.Examples.WinUI/appsettings.json
@@ -11,6 +11,17 @@
   },
   "messageComposer": {
     "serializerType": "AutoBinary",
+    // Optional RawHex log-enrichment example:
+    // 1. Change serializerType to "RawHex".
+    // 2. Add a bitFieldSchema like the README example below.
+    // "bitFieldSchema": {
+    //   "payloadLengthBytes": 4,
+    //   "fields": [
+    //     { "name": "prefix", "bitOffset": 0, "bitLength": 8 },
+    //     { "name": "register", "bitOffset": 8, "bitLength": 16, "endianness": "BigEndian" },
+    //     { "name": "tail", "bitOffset": 24, "bitLength": 8 }
+    //   ]
+    // },
     "outboundMessageId": "100",
     "outboundBody": "hello from the mvvm winui lab"
   },

--- a/src/CommLib.Domain/Messaging/BitFieldCodec.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldCodec.cs
@@ -1,40 +1,35 @@
 namespace CommLib.Domain.Messaging;
 
 /// <summary>
-/// raw payload를 bitfield 단위로 읽고 쓰는 공용 codec입니다.
+/// Reads and writes scalar values against bitfield definitions in a raw payload.
 /// </summary>
 public static class BitFieldCodec
 {
     /// <summary>
-    /// 지정한 bitfield를 unsigned 정수로 읽습니다.
+    /// Reads a bitfield as an unsigned integer.
     /// </summary>
-    /// <param name="payload">원본 payload입니다.</param>
-    /// <param name="field">읽을 field 정의입니다.</param>
-    /// <returns>field 구간의 unsigned 값입니다.</returns>
+    /// <param name="payload">The source payload.</param>
+    /// <param name="field">The field to read.</param>
+    /// <returns>The unsigned value stored in the field.</returns>
     public static ulong ReadUnsigned(ReadOnlySpan<byte> payload, BitFieldDefinition field)
     {
         ArgumentNullException.ThrowIfNull(field);
         EnsureFieldFits(payload.Length, field);
 
-        ulong value = 0;
-        for (var bitIndex = 0; bitIndex < field.BitLength; bitIndex++)
+        return field.Endianness switch
         {
-            var absoluteBitIndex = field.BitOffset + bitIndex;
-            var byteIndex = absoluteBitIndex / 8;
-            var bitInByte = absoluteBitIndex % 8;
-            var bit = (payload[byteIndex] >> bitInByte) & 0x01;
-            value |= (ulong)bit << bitIndex;
-        }
-
-        return value;
+            BitFieldEndianness.LittleEndian => ReadUnsignedLittleEndian(payload, field),
+            BitFieldEndianness.BigEndian => ReadUnsignedBigEndian(payload, field),
+            _ => throw new ArgumentOutOfRangeException(nameof(field), $"Bit field '{field.Name}' has an unsupported endianness.")
+        };
     }
 
     /// <summary>
-    /// 지정한 bitfield를 signed 정수로 읽습니다.
+    /// Reads a bitfield as a signed integer.
     /// </summary>
-    /// <param name="payload">원본 payload입니다.</param>
-    /// <param name="field">읽을 field 정의입니다.</param>
-    /// <returns>field 구간의 signed 값입니다.</returns>
+    /// <param name="payload">The source payload.</param>
+    /// <param name="field">The field to read.</param>
+    /// <returns>The signed value stored in the field.</returns>
     public static long ReadSigned(ReadOnlySpan<byte> payload, BitFieldDefinition field)
     {
         var value = ReadUnsigned(payload, field);
@@ -54,17 +49,68 @@ public static class BitFieldCodec
     }
 
     /// <summary>
-    /// 지정한 bitfield 구간에 unsigned 정수 값을 씁니다.
+    /// Writes an unsigned integer value into a bitfield.
     /// </summary>
-    /// <param name="payload">쓰기 대상 payload입니다.</param>
-    /// <param name="field">쓸 field 정의입니다.</param>
-    /// <param name="value">쓸 unsigned 값입니다.</param>
+    /// <param name="payload">The destination payload.</param>
+    /// <param name="field">The field to write.</param>
+    /// <param name="value">The unsigned value to write.</param>
     public static void WriteUnsigned(Span<byte> payload, BitFieldDefinition field, ulong value)
     {
         ArgumentNullException.ThrowIfNull(field);
         EnsureFieldFits(payload.Length, field);
         EnsureValueFits(field, value);
 
+        switch (field.Endianness)
+        {
+            case BitFieldEndianness.LittleEndian:
+                WriteUnsignedLittleEndian(payload, field, value);
+                return;
+
+            case BitFieldEndianness.BigEndian:
+                WriteUnsignedBigEndian(payload, field, value);
+                return;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(field), $"Bit field '{field.Name}' has an unsupported endianness.");
+        }
+    }
+
+    private static ulong ReadUnsignedLittleEndian(ReadOnlySpan<byte> payload, BitFieldDefinition field)
+    {
+        ulong value = 0;
+        for (var bitIndex = 0; bitIndex < field.BitLength; bitIndex++)
+        {
+            var absoluteBitIndex = field.BitOffset + bitIndex;
+            var byteIndex = absoluteBitIndex / 8;
+            var bitInByte = absoluteBitIndex % 8;
+            var bit = (payload[byteIndex] >> bitInByte) & 0x01;
+            value |= (ulong)bit << bitIndex;
+        }
+
+        return value;
+    }
+
+    private static ulong ReadUnsignedBigEndian(ReadOnlySpan<byte> payload, BitFieldDefinition field)
+    {
+        if (field.BitLength <= 8)
+        {
+            return ReadUnsignedLittleEndian(payload, field);
+        }
+
+        var byteIndex = field.BitOffset / 8;
+        var byteCount = field.BitLength / 8;
+        ulong value = 0;
+
+        for (var index = 0; index < byteCount; index++)
+        {
+            value = (value << 8) | payload[byteIndex + index];
+        }
+
+        return value;
+    }
+
+    private static void WriteUnsignedLittleEndian(Span<byte> payload, BitFieldDefinition field, ulong value)
+    {
         for (var bitIndex = 0; bitIndex < field.BitLength; bitIndex++)
         {
             var absoluteBitIndex = field.BitOffset + bitIndex;
@@ -81,6 +127,24 @@ public static class BitFieldCodec
             {
                 payload[byteIndex] &= unchecked((byte)~mask);
             }
+        }
+    }
+
+    private static void WriteUnsignedBigEndian(Span<byte> payload, BitFieldDefinition field, ulong value)
+    {
+        if (field.BitLength <= 8)
+        {
+            WriteUnsignedLittleEndian(payload, field, value);
+            return;
+        }
+
+        var byteIndex = field.BitOffset / 8;
+        var byteCount = field.BitLength / 8;
+
+        for (var index = 0; index < byteCount; index++)
+        {
+            var shift = (byteCount - index - 1) * 8;
+            payload[byteIndex + index] = (byte)((value >> shift) & 0xFF);
         }
     }
 

--- a/src/CommLib.Domain/Messaging/BitFieldDefinition.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldDefinition.cs
@@ -1,17 +1,22 @@
 namespace CommLib.Domain.Messaging;
 
 /// <summary>
-/// raw payload 안의 bitfield 한 구간을 설명하는 정의입니다.
+/// Describes a named bitfield range inside a raw payload.
 /// </summary>
 public sealed record BitFieldDefinition
 {
     /// <summary>
-    /// <see cref="BitFieldDefinition"/> 인스턴스를 초기화합니다.
+    /// Initializes a <see cref="BitFieldDefinition"/> instance.
     /// </summary>
-    /// <param name="name">필드 이름입니다.</param>
-    /// <param name="bitOffset">payload 시작점 기준 bit offset입니다. bit 0은 첫 번째 byte의 LSB입니다.</param>
-    /// <param name="bitLength">필드 bit 길이입니다. 현재 최대 64 bit까지 지원합니다.</param>
-    public BitFieldDefinition(string name, int bitOffset, int bitLength)
+    /// <param name="name">The field name.</param>
+    /// <param name="bitOffset">The field offset from the start of the payload. Bit 0 is the LSB of the first byte.</param>
+    /// <param name="bitLength">The field length in bits. The current implementation supports up to 64 bits.</param>
+    /// <param name="endianness">The byte order used when a field spans multiple whole bytes.</param>
+    public BitFieldDefinition(
+        string name,
+        int bitOffset,
+        int bitLength,
+        BitFieldEndianness endianness = BitFieldEndianness.LittleEndian)
     {
         if (string.IsNullOrWhiteSpace(name))
         {
@@ -28,23 +33,43 @@ public sealed record BitFieldDefinition
             throw new ArgumentOutOfRangeException(nameof(bitLength), "Bit field length must be between 1 and 64 bits.");
         }
 
+        if (!Enum.IsDefined(endianness))
+        {
+            throw new ArgumentOutOfRangeException(nameof(endianness), "Bit field endianness is invalid.");
+        }
+
+        if (endianness == BitFieldEndianness.BigEndian &&
+            bitLength > 8 &&
+            (bitOffset % 8 != 0 || bitLength % 8 != 0))
+        {
+            throw new ArgumentException(
+                "Big-endian bit fields wider than one byte must be byte-aligned and use a whole-byte length.",
+                nameof(bitLength));
+        }
+
         Name = name;
         BitOffset = bitOffset;
         BitLength = bitLength;
+        Endianness = endianness;
     }
 
     /// <summary>
-    /// 필드 이름입니다.
+    /// Gets the field name.
     /// </summary>
     public string Name { get; }
 
     /// <summary>
-    /// payload 시작점 기준 bit offset입니다. bit 0은 첫 번째 byte의 LSB입니다.
+    /// Gets the field offset from the start of the payload. Bit 0 is the LSB of the first byte.
     /// </summary>
     public int BitOffset { get; }
 
     /// <summary>
-    /// 필드 bit 길이입니다.
+    /// Gets the field length in bits.
     /// </summary>
     public int BitLength { get; }
+
+    /// <summary>
+    /// Gets the byte order used when a field spans multiple whole bytes.
+    /// </summary>
+    public BitFieldEndianness Endianness { get; }
 }

--- a/src/CommLib.Domain/Messaging/BitFieldEndianness.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldEndianness.cs
@@ -1,0 +1,17 @@
+namespace CommLib.Domain.Messaging;
+
+/// <summary>
+/// Controls the byte order used for multi-byte bitfield values.
+/// </summary>
+public enum BitFieldEndianness
+{
+    /// <summary>
+    /// The lowest-addressed byte is the least-significant byte.
+    /// </summary>
+    LittleEndian = 0,
+
+    /// <summary>
+    /// The lowest-addressed byte is the most-significant byte.
+    /// </summary>
+    BigEndian = 1
+}

--- a/src/CommLib.Domain/Messaging/BitFieldPayloadField.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldPayloadField.cs
@@ -1,33 +1,38 @@
 namespace CommLib.Domain.Messaging;
 
 /// <summary>
-/// payload schema 안의 하나의 named bitfield를 정의합니다.
+/// Defines one named bitfield inside a payload schema.
 /// </summary>
 public sealed class BitFieldPayloadField
 {
     /// <summary>
-    /// 필드 이름입니다.
+    /// Gets or initializes the field name.
     /// </summary>
     public required string Name { get; init; }
 
     /// <summary>
-    /// payload 시작 기준 bit offset입니다. bit 0은 첫 번째 byte의 LSB입니다.
+    /// Gets or initializes the field offset from the start of the payload. Bit 0 is the LSB of the first byte.
     /// </summary>
     public int BitOffset { get; init; }
 
     /// <summary>
-    /// 필드 bit 길이입니다.
+    /// Gets or initializes the field length in bits.
     /// </summary>
     public int BitLength { get; init; }
 
     /// <summary>
-    /// 이 필드를 unsigned/signed 중 어떤 방식으로 읽고 쓸지 지정합니다.
+    /// Gets or initializes whether the value should be interpreted as unsigned or signed.
     /// </summary>
     public BitFieldScalarKind ScalarKind { get; init; } = BitFieldScalarKind.Unsigned;
 
     /// <summary>
-    /// low-level bit codec가 사용하는 <see cref="BitFieldDefinition"/>으로 변환합니다.
+    /// Gets or initializes the byte order used when a field spans multiple whole bytes.
     /// </summary>
-    /// <returns>검증 가능한 <see cref="BitFieldDefinition"/> 인스턴스입니다.</returns>
-    public BitFieldDefinition ToDefinition() => new(Name, BitOffset, BitLength);
+    public BitFieldEndianness Endianness { get; init; } = BitFieldEndianness.LittleEndian;
+
+    /// <summary>
+    /// Converts the schema field to the low-level codec definition.
+    /// </summary>
+    /// <returns>A validated <see cref="BitFieldDefinition"/> instance.</returns>
+    public BitFieldDefinition ToDefinition() => new(Name, BitOffset, BitLength, Endianness);
 }

--- a/src/CommLib.Domain/Messaging/MessagePayloadFormatter.cs
+++ b/src/CommLib.Domain/Messaging/MessagePayloadFormatter.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 
 namespace CommLib.Domain.Messaging;
@@ -28,6 +29,46 @@ public static class MessagePayloadFormatter
     }
 
     /// <summary>
+    /// Tries to inspect a binary payload with a bitfield schema and returns a compact field summary for logs.
+    /// </summary>
+    /// <param name="message">The message whose payload should be inspected.</param>
+    /// <param name="schema">The optional schema to apply to the payload.</param>
+    /// <param name="summary">The formatted field summary when inspection succeeds.</param>
+    /// <param name="error">The inspection error when schema inspection fails.</param>
+    /// <returns><see langword="true"/> when a schema summary was produced; otherwise <see langword="false"/>.</returns>
+    public static bool TryFormatBitFieldSummary(
+        IMessage message,
+        BitFieldPayloadSchema? schema,
+        out string? summary,
+        out string? error)
+    {
+        summary = null;
+        error = null;
+
+        if (schema is null || message is not IBinaryMessagePayload binaryPayload)
+        {
+            return false;
+        }
+
+        try
+        {
+            var values = BitFieldPayloadSchemaCodec.Inspect(schema, binaryPayload.Payload.Span);
+            if (values.Count == 0)
+            {
+                return false;
+            }
+
+            summary = FormatBitFieldValues(values);
+            return true;
+        }
+        catch (InvalidOperationException exception)
+        {
+            error = exception.Message;
+            return false;
+        }
+    }
+
+    /// <summary>
     /// raw binary payload를 공백 구분 대문자 hex 문자열로 변환합니다.
     /// </summary>
     /// <param name="payload">변환할 payload 바이트입니다.</param>
@@ -50,6 +91,26 @@ public static class MessagePayloadFormatter
             }
 
             builder.Append(hex, index * 2, 2);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string FormatBitFieldValues(IReadOnlyList<BitFieldFieldValue> values)
+    {
+        var builder = new StringBuilder();
+
+        for (var index = 0; index < values.Count; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(", ");
+            }
+
+            var value = values[index];
+            builder.Append(value.Field.Name);
+            builder.Append('=');
+            builder.Append(value.Value.ToString(CultureInfo.InvariantCulture));
         }
 
         return builder.ToString();

--- a/tests/CommLib.Unit.Tests/BitFieldCodecTests.cs
+++ b/tests/CommLib.Unit.Tests/BitFieldCodecTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace CommLib.Unit.Tests;
 
 /// <summary>
-/// raw payload bitfield codec가 비트 오프셋 기준 read/write를 올바르게 수행하는지 검증합니다.
+/// Verifies that the low-level bitfield codec reads and writes payload bits correctly.
 /// </summary>
 public sealed class BitFieldCodecTests
 {
@@ -39,6 +39,36 @@ public sealed class BitFieldCodecTests
     }
 
     [Fact]
+    public void ReadUnsigned_BigEndianWholeByteField_ReturnsExpectedValue()
+    {
+        var field = new BitFieldDefinition("register", 0, 16, BitFieldEndianness.BigEndian);
+
+        var value = BitFieldCodec.ReadUnsigned(new byte[] { 0x12, 0x34 }, field);
+
+        Assert.Equal(0x1234UL, value);
+    }
+
+    [Fact]
+    public void ReadUnsigned_BigEndianWholeByteFieldAtOffset_ReturnsExpectedValue()
+    {
+        var field = new BitFieldDefinition("register", 8, 16, BitFieldEndianness.BigEndian);
+
+        var value = BitFieldCodec.ReadUnsigned(new byte[] { 0xAA, 0x12, 0x34, 0xBB }, field);
+
+        Assert.Equal(0x1234UL, value);
+    }
+
+    [Fact]
+    public void ReadSigned_BigEndianWholeByteField_SignExtendsValue()
+    {
+        var field = new BitFieldDefinition("delta", 0, 16, BitFieldEndianness.BigEndian);
+
+        var value = BitFieldCodec.ReadSigned(new byte[] { 0xFF, 0x9C }, field);
+
+        Assert.Equal(-100, value);
+    }
+
+    [Fact]
     public void WriteUnsigned_FieldAcrossByteBoundary_WritesExpectedBitsOnly()
     {
         var field = new BitFieldDefinition("temperatureRaw", 4, 12);
@@ -47,6 +77,28 @@ public sealed class BitFieldCodecTests
         BitFieldCodec.WriteUnsigned(payload, field, 0xABC);
 
         Assert.Equal(new byte[] { 0xCF, 0xAB, 0xF0 }, payload);
+    }
+
+    [Fact]
+    public void WriteUnsigned_BigEndianWholeByteField_WritesMostSignificantByteFirst()
+    {
+        var field = new BitFieldDefinition("register", 0, 16, BitFieldEndianness.BigEndian);
+        var payload = new byte[2];
+
+        BitFieldCodec.WriteUnsigned(payload, field, 0x1234);
+
+        Assert.Equal(new byte[] { 0x12, 0x34 }, payload);
+    }
+
+    [Fact]
+    public void WriteUnsigned_BigEndianWholeByteFieldAtOffset_PreservesSurroundingBytes()
+    {
+        var field = new BitFieldDefinition("register", 8, 16, BitFieldEndianness.BigEndian);
+        var payload = new byte[] { 0xAA, 0x00, 0x00, 0xBB };
+
+        BitFieldCodec.WriteUnsigned(payload, field, 0x1234);
+
+        Assert.Equal(new byte[] { 0xAA, 0x12, 0x34, 0xBB }, payload);
     }
 
     [Fact]
@@ -68,5 +120,13 @@ public sealed class BitFieldCodecTests
         var exception = Assert.Throws<ArgumentOutOfRangeException>(() => BitFieldCodec.ReadUnsigned(new byte[] { 0x00, 0x01 }, field));
 
         Assert.Contains("status", exception.Message);
+    }
+
+    [Fact]
+    public void Ctor_BigEndianMultiByteFieldWithoutWholeBytes_Throws()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => new BitFieldDefinition("bad", 4, 12, BitFieldEndianness.BigEndian));
+
+        Assert.Contains("byte-aligned", exception.Message);
     }
 }

--- a/tests/CommLib.Unit.Tests/BitFieldPayloadSchemaCodecTests.cs
+++ b/tests/CommLib.Unit.Tests/BitFieldPayloadSchemaCodecTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace CommLib.Unit.Tests;
 
 /// <summary>
-/// bitfield payload schema codec가 named field 값을 raw payload로 compose/inspect하는지 검증합니다.
+/// Verifies that the schema-backed payload codec can compose and inspect named fields.
 /// </summary>
 public sealed class BitFieldPayloadSchemaCodecTests
 {
@@ -12,7 +12,7 @@ public sealed class BitFieldPayloadSchemaCodecTests
     public void Compose_SignedAndUnsignedFields_ReturnsExpectedPayload()
     {
         var payload = BitFieldPayloadSchemaCodec.Compose(
-            CreateSchema(),
+            CreateLittleEndianSchema(),
             new[]
             {
                 new BitFieldFieldAssignment("mode", 5),
@@ -26,7 +26,7 @@ public sealed class BitFieldPayloadSchemaCodecTests
     [Fact]
     public void Inspect_SignedAndUnsignedFields_ReturnsExpectedValues()
     {
-        var values = BitFieldPayloadSchemaCodec.Inspect(CreateSchema(), new byte[] { 0xCD, 0xF9 });
+        var values = BitFieldPayloadSchemaCodec.Inspect(CreateLittleEndianSchema(), new byte[] { 0xCD, 0xF9 });
 
         Assert.Collection(
             values,
@@ -51,11 +51,90 @@ public sealed class BitFieldPayloadSchemaCodecTests
     }
 
     [Fact]
+    public void Compose_BigEndianWholeByteField_ReturnsExpectedPayload()
+    {
+        var payload = BitFieldPayloadSchemaCodec.Compose(
+            CreateBigEndianSchema(),
+            new[]
+            {
+                new BitFieldFieldAssignment("register", 0x1234),
+                new BitFieldFieldAssignment("tail", 0xAB)
+            });
+
+        Assert.Equal(new byte[] { 0x12, 0x34, 0xAB }, payload);
+    }
+
+    [Fact]
+    public void Inspect_BigEndianWholeByteField_ReturnsExpectedValues()
+    {
+        var values = BitFieldPayloadSchemaCodec.Inspect(CreateBigEndianSchema(), new byte[] { 0x12, 0x34, 0xAB });
+
+        Assert.Collection(
+            values,
+            item =>
+            {
+                Assert.Equal("register", item.Field.Name);
+                Assert.Equal(BitFieldEndianness.BigEndian, item.Field.Endianness);
+                Assert.Equal(4660m, item.Value);
+            },
+            item =>
+            {
+                Assert.Equal("tail", item.Field.Name);
+                Assert.Equal(BitFieldEndianness.LittleEndian, item.Field.Endianness);
+                Assert.Equal(171m, item.Value);
+            });
+    }
+
+    [Fact]
+    public void Compose_MixedEndianSchemaWithOffsetAndSignedField_ReturnsExpectedPayload()
+    {
+        var payload = BitFieldPayloadSchemaCodec.Compose(
+            CreateMixedEndianSchema(),
+            new[]
+            {
+                new BitFieldFieldAssignment("prefix", 0xAA),
+                new BitFieldFieldAssignment("register", 0x1234),
+                new BitFieldFieldAssignment("delta", -100)
+            });
+
+        Assert.Equal(new byte[] { 0xAA, 0x12, 0x34, 0xFF, 0x9C }, payload);
+    }
+
+    [Fact]
+    public void Inspect_MixedEndianSchemaWithOffsetAndSignedField_ReturnsExpectedValues()
+    {
+        var values = BitFieldPayloadSchemaCodec.Inspect(
+            CreateMixedEndianSchema(),
+            new byte[] { 0xAA, 0x12, 0x34, 0xFF, 0x9C });
+
+        Assert.Collection(
+            values,
+            item =>
+            {
+                Assert.Equal("prefix", item.Field.Name);
+                Assert.Equal(170m, item.Value);
+            },
+            item =>
+            {
+                Assert.Equal("register", item.Field.Name);
+                Assert.Equal(BitFieldEndianness.BigEndian, item.Field.Endianness);
+                Assert.Equal(4660m, item.Value);
+            },
+            item =>
+            {
+                Assert.Equal("delta", item.Field.Name);
+                Assert.Equal(BitFieldScalarKind.Signed, item.ScalarKind);
+                Assert.Equal(BitFieldEndianness.BigEndian, item.Field.Endianness);
+                Assert.Equal(-100m, item.Value);
+            });
+    }
+
+    [Fact]
     public void Compose_UnknownField_Throws()
     {
         var exception = Assert.Throws<InvalidOperationException>(
             () => BitFieldPayloadSchemaCodec.Compose(
-                CreateSchema(),
+                CreateLittleEndianSchema(),
                 new[] { new BitFieldFieldAssignment("unknown", 1) }));
 
         Assert.Contains("unknown", exception.Message);
@@ -66,7 +145,7 @@ public sealed class BitFieldPayloadSchemaCodecTests
     {
         var exception = Assert.Throws<InvalidOperationException>(
             () => BitFieldPayloadSchemaCodec.Compose(
-                CreateSchema(),
+                CreateLittleEndianSchema(),
                 new[] { new BitFieldFieldAssignment("mode", 1.5m) }));
 
         Assert.Contains("integer", exception.Message);
@@ -76,12 +155,12 @@ public sealed class BitFieldPayloadSchemaCodecTests
     public void Inspect_PayloadLengthMismatch_Throws()
     {
         var exception = Assert.Throws<InvalidOperationException>(
-            () => BitFieldPayloadSchemaCodec.Inspect(CreateSchema(), new byte[] { 0xCD }));
+            () => BitFieldPayloadSchemaCodec.Inspect(CreateLittleEndianSchema(), new byte[] { 0xCD }));
 
         Assert.Contains("does not match", exception.Message);
     }
 
-    private static BitFieldPayloadSchema CreateSchema()
+    private static BitFieldPayloadSchema CreateLittleEndianSchema()
     {
         return new BitFieldPayloadSchema
         {
@@ -91,6 +170,62 @@ public sealed class BitFieldPayloadSchemaCodecTests
                 new BitFieldPayloadField { Name = "mode", BitOffset = 0, BitLength = 3 },
                 new BitFieldPayloadField { Name = "enabled", BitOffset = 3, BitLength = 1 },
                 new BitFieldPayloadField { Name = "delta", BitOffset = 4, BitLength = 12, ScalarKind = BitFieldScalarKind.Signed }
+            }
+        };
+    }
+
+    private static BitFieldPayloadSchema CreateBigEndianSchema()
+    {
+        return new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 3,
+            Fields = new[]
+            {
+                new BitFieldPayloadField
+                {
+                    Name = "register",
+                    BitOffset = 0,
+                    BitLength = 16,
+                    Endianness = BitFieldEndianness.BigEndian
+                },
+                new BitFieldPayloadField
+                {
+                    Name = "tail",
+                    BitOffset = 16,
+                    BitLength = 8
+                }
+            }
+        };
+    }
+
+    private static BitFieldPayloadSchema CreateMixedEndianSchema()
+    {
+        return new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 5,
+            Fields = new[]
+            {
+                new BitFieldPayloadField
+                {
+                    Name = "prefix",
+                    BitOffset = 0,
+                    BitLength = 8
+                },
+                new BitFieldPayloadField
+                {
+                    Name = "register",
+                    BitOffset = 8,
+                    BitLength = 16,
+                    Endianness = BitFieldEndianness.BigEndian
+                },
+                new BitFieldPayloadField
+                {
+                    Name = "delta",
+                    BitOffset = 24,
+                    BitLength = 16,
+                    ScalarKind = BitFieldScalarKind.Signed,
+                    Endianness = BitFieldEndianness.BigEndian
+                }
             }
         };
     }

--- a/tests/CommLib.Unit.Tests/BitFieldPayloadSchemaValidatorTests.cs
+++ b/tests/CommLib.Unit.Tests/BitFieldPayloadSchemaValidatorTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace CommLib.Unit.Tests;
 
 /// <summary>
-/// bitfield payload schema validator가 payload 길이, overlap, duplicate 조건을 검증하는지 확인합니다.
+/// Verifies that the payload schema validator catches invalid field layouts.
 /// </summary>
 public sealed class BitFieldPayloadSchemaValidatorTests
 {
@@ -59,5 +59,28 @@ public sealed class BitFieldPayloadSchemaValidatorTests
         var exception = Assert.Throws<InvalidOperationException>(() => BitFieldPayloadSchemaValidator.ValidateAndThrow(schema));
 
         Assert.Contains("overlap", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateAndThrow_BigEndianNonByteAlignedField_Throws()
+    {
+        var schema = new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 2,
+            Fields = new[]
+            {
+                new BitFieldPayloadField
+                {
+                    Name = "register",
+                    BitOffset = 4,
+                    BitLength = 12,
+                    Endianness = BitFieldEndianness.BigEndian
+                }
+            }
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BitFieldPayloadSchemaValidator.ValidateAndThrow(schema));
+
+        Assert.Contains("byte-aligned", exception.InnerException?.Message ?? exception.Message);
     }
 }

--- a/tests/CommLib.Unit.Tests/MessagePayloadFormatterTests.cs
+++ b/tests/CommLib.Unit.Tests/MessagePayloadFormatterTests.cs
@@ -32,5 +32,53 @@ public sealed class MessagePayloadFormatterTests
         Assert.Equal(string.Empty, body);
     }
 
+    [Fact]
+    public void TryFormatBitFieldSummary_BigEndianSchemaAtOffset_ReturnsFieldSummary()
+    {
+        var message = new BinaryMessageModel(10, new byte[] { 0xAA, 0x12, 0x34, 0x7F });
+        var schema = new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 4,
+            Fields = new[]
+            {
+                new BitFieldPayloadField { Name = "prefix", BitOffset = 0, BitLength = 8 },
+                new BitFieldPayloadField
+                {
+                    Name = "register",
+                    BitOffset = 8,
+                    BitLength = 16,
+                    Endianness = BitFieldEndianness.BigEndian
+                },
+                new BitFieldPayloadField { Name = "tail", BitOffset = 24, BitLength = 8 }
+            }
+        };
+
+        var result = MessagePayloadFormatter.TryFormatBitFieldSummary(message, schema, out var summary, out var error);
+
+        Assert.True(result);
+        Assert.Equal("prefix=170, register=4660, tail=127", summary);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void TryFormatBitFieldSummary_PayloadLengthMismatch_ReturnsErrorWithoutThrowing()
+    {
+        var message = new BinaryMessageModel(10, new byte[] { 0x12 });
+        var schema = new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 2,
+            Fields = new[]
+            {
+                new BitFieldPayloadField { Name = "register", BitOffset = 0, BitLength = 16 }
+            }
+        };
+
+        var result = MessagePayloadFormatter.TryFormatBitFieldSummary(message, schema, out var summary, out var error);
+
+        Assert.False(result);
+        Assert.Null(summary);
+        Assert.Contains("does not match", error);
+    }
+
     private sealed record NoPayloadMessage(ushort MessageId) : IMessage;
 }


### PR DESCRIPTION
## Summary

This is a stacked PR on top of `feat/bitfield-endianness`.
It keeps the follow-up scope narrow: endian-aware schema metadata is now consumed by the WinUI example and shared payload formatter so binary session logs can append decoded field summaries.

## What changed

- add `BitFieldEndianness` to low-level and schema-facing bitfield definitions
- teach `BitFieldCodec` to support whole-byte `BigEndian` multi-byte fields while preserving the existing `payload[0]` LSB = bit `0` numbering rule
- let `MessagePayloadFormatter` inspect binary payloads through an optional `BitFieldPayloadSchema`
- thread optional `messageComposer.bitFieldSchema` through WinUI settings and session logging
- add focused unit coverage for mixed-endian schema compose/inspect and safe schema decode errors
- document the JSON setup for `RawHex + bitFieldSchema` in the WinUI example

## Validation

- `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --filter "BitFieldCodecTests|BitFieldPayloadSchemaCodecTests|BitFieldPayloadSchemaValidatorTests|MessagePayloadFormatterTests" --no-restore`
- `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`

## Notes

- This PR intentionally stays above the serializer/composer/logging seam.
- It does not add an in-app schema editor.
- `BigEndian` currently applies only to byte-aligned multi-byte fields whose lengths are whole-byte multiples.
