### PR TITLE
feat(messaging): add rawhex and schema-backed bitfield payload support

### DIFF
--- a/CHANGELOG_AGENT.md
+++ b/CHANGELOG_AGENT.md
@@ -1,5 +1,73 @@
 # CHANGELOG_AGENT
 
+## 2026-04-06
+- Rotated the ongoing raw-hex work off `feat/winui-localization-foundation` and onto the dedicated branch `feat/rawhex-compose-flow` after the feature scope clearly diverged from the already-merged WinUI localization line.
+- Reconciled the new user request with the current repo state and chose the smallest TDD-backed raw-hex implementation slice instead of widening immediately into WinUI UI work or future bitfield schema mapping.
+- Added failing tests first for:
+  - `MessagePayloadFormatter`
+  - `RawHexSerializer`
+  - `SerializerFactory` support for `RawHex`
+- Introduced the reusable binary payload groundwork in `CommLib.Domain`:
+  - added `IBinaryMessagePayload`
+  - added `BinaryMessageModel`, `BinaryRequestMessageModel`, and `BinaryResponseMessageModel`
+  - added `MessagePayloadFormatter` so logs/UI code can render binary messages as uppercase space-delimited hex
+- Added `RawHexSerializer` in `CommLib.Infrastructure.Protocol`:
+  - preserves the existing message/request/response metadata header shape
+  - appends raw payload bytes after the header
+  - accepts either direct binary payload messages or whitespace-tolerant outbound hex text bodies
+  - deserializes inbound payloads into binary-capable message models
+- Extended `SerializerFactory` so `SerializerOptions.Type = "RawHex"` resolves to the new serializer.
+- Updated the console example and WinUI session receive logging to use `MessagePayloadFormatter` instead of assuming `IMessageBody` is always present.
+- Verified the slice with:
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
+  - `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --no-restore`
+  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj --no-restore`
+- Continued the next WinUI-facing raw-hex slice in TDD:
+  - added `SerializerTypes`, `HexPayloadParser`, and `OutboundMessageComposer`
+  - added unit tests for serializer-driven outbound message composition
+  - persisted serializer selection in WinUI `MessageComposerAppSettings`
+  - added shared serializer choice state to `DeviceLabSettingsViewModel`
+  - added serializer selectors plus serializer-mode hint text to both `Device Lab` and `Settings`
+  - changed `IDeviceLabSessionService.SendAsync` to accept a composed `IMessage`
+  - changed outbound session logging to use `MessagePayloadFormatter`
+  - localized the WinUI raw-hex validation failure path
+  - updated the WinUI README/appsettings defaults for the new serializer selection
+- Verified the WinUI-facing slice with:
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
+  - `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --no-restore`
+  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj --no-restore`
+- Added a focused raw-hex TCP roundtrip validation slice in infrastructure tests:
+  - added `RawHexConnectionManagerRoundtripTests`
+  - exercised the real `ConnectionManager` + `TcpTransport` + `LengthPrefixedProtocol` + `RawHexSerializer` path instead of only unit-level serializer coverage
+  - covered both direct binary payload messages and the existing hex-text bridge path
+  - asserted that the echoed inbound payload still formats as uppercase spaced hex through `MessagePayloadFormatter`
+- Verified the transport/session roundtrip slice with:
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~RawHexConnectionManagerRoundtripTests"`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
+- Ran a live `win-x64` WinUI raw-hex TCP validation pass through the in-app mock endpoint:
+  - temporarily pinned the runtime `appsettings.json` to English, TCP loopback, `RawHex`, message id `321`, and body `DE AD BE EF`
+  - launched the app, invoked `Start Mock`, `Connect`, and `Send` through UI Automation
+  - confirmed matching outbound and inbound `DE AD BE EF` log entries in the live log
+- Found and fixed a WinUI command-state regression during that live pass:
+  - after connect succeeded, `Send` stayed disabled because `MainViewModel` async command handlers resumed off the UI context after `ConfigureAwait(false)`
+  - the same UI-layer pattern existed in `SettingsViewModel` save/reload commands
+  - removed `ConfigureAwait(false)` from those WinUI async command handlers so observable state and command enablement resume on the UI context
+- Re-verified the fix with:
+  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
+  - a repeated `win-x64` UI Automation raw-hex TCP roundtrip that reached outbound and inbound `DE AD BE EF`
+- Started the first bit-level foundation slice in TDD instead of jumping straight into serializer-setting or WinUI schema editing:
+  - added `BitFieldDefinition` as the named bit-range contract
+  - added `BitFieldCodec` for unsigned reads, signed reads, and unsigned in-place writes
+  - fixed the initial convention as `payload[0]` LSB = bit `0`
+  - covered single-bit reads, cross-byte reads, signed sign-extension, in-place writes, and bounds/value validation in `BitFieldCodecTests`
+- Verified the bitfield foundation slice with:
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore --filter "FullyQualifiedName~BitFieldCodecTests"`
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
+
 ## 2026-04-03
 - Reconciled `PROGRESS.md`, `AGENT.md`, `docs/current-plan.md`, recent commits, branch state, and the current WinUI example code.
 - Confirmed that the worktree was clean, the active branch name no longer matched the latest example-focused work, and no canonical root state files existed yet.
@@ -109,3 +177,34 @@
   - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --collect:"XPlat Code Coverage"`
   - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --collect:"XPlat Code Coverage"`
   - Cobertura XML outputs generated under each test project's `TestResults/.../coverage.cobertura.xml`
+- Published the WinUI follow-up branch and captured the delivery state:
+  - split the local work into `1601dbc` (`build(repo): centralize package versions and coverage tooling`), `f21d5dd` (`feat(examples): localize and streamline winui device lab`), and `bad9ee7` (`docs(agent): record winui follow-up state`)
+  - pushed `feat/winui-localization-foundation` to `commlib-hub`
+  - the GitHub connector could not open the PR directly because pull-request creation returned `403 Resource not accessible by integration`
+  - used `gh` CLI as fallback to open PR `#3` (`[codex] localize and streamline the WinUI device lab`)
+  - later confirmed via `gh pr view 3` that the PR is now merged into `main`
+- Reviewed the repo's current support for raw hex and bitfield-shaped payloads:
+  - confirmed that the live path stops at frame boundaries plus the text-oriented `AutoBinary` serializer, with no existing bit-mask/bit-shift payload decoder in `src/`
+  - designed the minimum safe direction as serializer/payload-codec work plus a small WinUI composer-mode addition rather than a transport/protocol rewrite
+  - recorded the implementation as deferred backlog, with raw-hex roundtrip support as the first slice and declarative bitfield schema mapping as a follow-up
+- Re-reviewed that design for longer-term extensibility:
+  - found that `SerializerOptions` / `ProtocolOptions` are currently flatter and more closed than `TransportOptions`, which would make future schema-specific settings awkward
+  - found that the real reuse seam is not only a new serializer, but also a binary payload representation plus display/formatting support so WinUI and logs stop assuming text-only bodies
+  - refined the backlog/decision notes toward a reusable binary-capable serializer/configuration path instead of a one-off `RawHex` bolt-on
+- Added the first schema-backed bitfield layer above the low-level raw-payload codec:
+  - introduced `BitFieldPayloadSchema`, `BitFieldPayloadField`, `BitFieldScalarKind`, `BitFieldFieldAssignment`, and `BitFieldFieldValue`
+  - added `BitFieldPayloadSchemaValidator` for payload-length, overlap, duplicate-name, and scalar-kind checks
+  - added `BitFieldPayloadSchemaCodec` to compose raw payload bytes from named field values and inspect raw payload bytes back into named field values
+  - chose `decimal` as the first schema API value type so the layer can represent signed and unsigned 64-bit scalar values without adding a heavier numeric abstraction yet
+- Added the first serializer-adjacent settings seam for that schema layer:
+  - `SerializerOptions` now carries an optional `BitFieldSchema`
+  - `DeviceProfileValidator` now rejects invalid schema definitions and rejects schema usage unless the serializer type is currently `RawHex`
+  - `OutboundMessageComposer` now has a schema-based binary payload overload that stays above the transport/protocol layer
+- Added focused unit coverage for the new schema slice:
+  - `BitFieldPayloadSchemaValidatorTests`
+  - `BitFieldPayloadSchemaCodecTests`
+  - updated `OutboundMessageComposerTests`, `DeviceProfileMapperTests`, and `DeviceProfileValidatorTests`
+- Verified the schema-backed slice with:
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
+  - `dotnet build commlib-codex-full.sln --no-restore`

--- a/CURRENT_PLAN.md
+++ b/CURRENT_PLAN.md
@@ -1,57 +1,60 @@
 # Current Plan
 
-Date: 2026-04-03
+Date: 2026-04-07
 
 ## Goal
-Keep the WinUI example follow-up moving with the next work unit focused on validating the new in-app mock peer flow across the remaining transports now that transport-specific panels, conservative page transitions, the scrollable auto-follow live log, the live `DeviceLabTheme` hookup, and the new repo-level package management baseline are all in place.
+Continue the raw hex / future bitfield support design by turning the new schema-backed payload layer into one real consumer, while keeping transport/protocol behavior unchanged and still stopping short of a WinUI schema editor.
 
 ## Confirmed Facts
-- Active branch is `feat/winui-localization-foundation`.
-- Localization foundation is implemented in the WinUI example:
-  - persisted `AppLanguageMode` in `appsettings.json`
-  - singleton `IAppLocalizer` / `AppLocalizer`
-  - localized shell/page/transport/language choices
-  - localized shell, Device Lab, and Settings page copy
-  - localized connection/session/status text on the main flow
-- `PointerWheelScrollBridge` forwards text-input mouse-wheel events back to the page `ScrollViewer` in `DeviceLabView` and `SettingsView`.
-- `AppShellView` animates `Device Lab` <-> `Settings` with a conservative opacity + horizontal slide transition while keeping the existing dual-host page structure.
-- `DeviceLabView` live log now uses a dedicated read-only multiline `TextBox` with its own scrollbars, no-wrap log lines, and end-of-document auto-follow.
-- The live-log follower now caches the inner `ScrollViewer` and explicitly drives it to `ScrollableHeight` after each text update instead of relying only on moving the text selection to the end.
-- `DeviceLabTheme` is now a live shared styling source for `AppShellView`, `DeviceLabView`, and `SettingsView` through safe brush/text/border resources.
-- `DeviceLabView` and `SettingsView` now collapse transport settings down to the currently selected transport instead of showing TCP/UDP/Multicast/Serial panels all at once.
-- `DeviceLabView` now includes a `Mock Endpoint` card backed by in-process `ILocalMockEndpointService` / `LocalMockEndpointService`.
-- Repo-level build/package configuration is now partially centralized:
-  - `Directory.Build.props` owns the shared `Nullable` and `ImplicitUsings` defaults
-  - `Directory.Packages.props` owns the package versions for WinUI/toolkit, `Microsoft.Extensions`, test packages, `coverlet.collector`, and `System.IO.Ports`
-  - project files now keep only project-specific package references without inline version numbers
-- Both test projects now reference `coverlet.collector` with `PrivateAssets=all`, and local `XPlat Code Coverage` runs generated Cobertura reports successfully.
-- The core WinUI example files now carry Korean comments around non-obvious lifecycle and control-flow areas, including DI bootstrap, shell/page transitions, wheel forwarding, live-log auto-follow, session state ownership, and local mock-peer runtime behavior.
-- The local mock peer flow currently behaves as follows:
-  - TCP starts a loopback echo listener on the selected TCP port and pins the host to `127.0.0.1`
-  - UDP starts a loopback echo listener on the selected UDP remote port and pins the remote host to `127.0.0.1`
-  - Multicast joins the selected group/port locally and replies back to the sender port for one-machine testing
-  - Serial remains external-only and surfaces as unavailable for the in-app mock flow
-- Verification completed on 2026-04-03:
-  - `dotnet build commlib-codex-full.sln`
-  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
-  - `dotnet test commlib-codex-full.sln`
-  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --collect:"XPlat Code Coverage"`
-  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --collect:"XPlat Code Coverage"`
-  - a `win-x64` UI Automation smoke that found the running window, located the mock-start button in the localized UI, confirmed the TCP-default screen hid the UDP-only `Local Port` label, invoked `Start Mock`, and completed a raw TCP echo roundtrip to `127.0.0.1:7001` with payload `mock-tcp-ping`
-  - a follow-up `win-x64` UI Automation smoke that started the local TCP mock, connected, sent 12 messages, and confirmed the live-log visible text range still reached the document end after the new explicit end-scroll logic
-- The earlier local `win-x64` startup crash still does not reproduce on the current branch state, so the sample remains on the restored `win-x64` default path.
-- Terminal-driven raw mouse-wheel injection was still not reliable enough to fully prove physical wheel behavior end-to-end, so real-pointer confirmation remains a manual follow-up rather than a closed automation item.
-- `PROGRESS.md` still rejects in-place `apply_patch` edits because of encoding corruption, but a date-based UTF-8 append path worked for the 2026-04-03 entry, so the file is usable for additive daily logs while full normalization remains deferred.
+- The repository continuity rules currently point at `AGENT.md`; a root `AGENT_RULES.md` file is not present.
+- Active branch is `feat/rawhex-compose-flow`.
+- GitHub PR `#3` (`[codex] localize and streamline the WinUI device lab`) was already merged into `main`; the ongoing raw-hex and bitfield work remains isolated on the dedicated feature branch.
+- The earlier WinUI follow-up work remains in place:
+  - persisted English/Korean `AppLanguageMode`
+  - localized shell / Device Lab / Settings / status copy
+  - pointer-wheel forwarding for page text inputs
+  - conservative Device Lab <-> Settings transition
+  - scrollable auto-follow live log
+  - active `DeviceLabTheme` hookup
+  - collapsed transport-specific panels
+  - in-app TCP / UDP / Multicast mock endpoint support
+  - repo-level package/build centralization and coverage collector support
+- The raw hex / bitfield direction still belongs in the serializer/composer path, not in transport creation or frame-boundary protocol logic.
+- The raw-hex foundation from 2026-04-06 remains in place:
+  - `IBinaryMessagePayload`
+  - `BinaryMessageModel`, `BinaryRequestMessageModel`, and `BinaryResponseMessageModel`
+  - `MessagePayloadFormatter`
+  - `RawHexSerializer`
+  - `SerializerFactory` support for `RawHex`
+  - WinUI serializer selection plus localized raw-hex validation
+  - transport-level and live WinUI raw-hex TCP roundtrip proof
+- The first low-level bitfield foundation from 2026-04-06 remains in place:
+  - `BitFieldDefinition`
+  - `BitFieldCodec`
+  - the `payload[0]` LSB = bit `0` convention
+- The first schema-backed bitfield slice completed on 2026-04-07 without widening into protocol changes or a WinUI schema editor:
+  - `BitFieldPayloadSchema`, `BitFieldPayloadField`, and `BitFieldScalarKind`
+  - `BitFieldFieldAssignment` and `BitFieldFieldValue`
+  - `BitFieldPayloadSchemaValidator`
+  - `BitFieldPayloadSchemaCodec` for named-field compose/inspect above `BitFieldCodec`
+  - optional `SerializerOptions.BitFieldSchema`
+  - `DeviceProfileValidator` enforcement that schema usage is currently valid only with `RawHex`
+  - `OutboundMessageComposer` overload for schema-driven binary payload composition
+- The first schema slice also chose a single numeric value representation for the API surface:
+  - compose assignments and inspect results use `decimal`
+  - this keeps the first schema API simple while still covering the full signed and unsigned 64-bit scalar range that the low-level codec already supports
+- Verification completed on 2026-04-07:
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
+  - `dotnet build commlib-codex-full.sln --no-restore`
+- The earlier `PROGRESS.md` encoding issue still remains deferred; this cycle did not attempt another in-place rewrite.
 
 ## Next Work Unit
-1. Manually validate the new UDP in-app mock peer flow from the running `win-x64` WinUI app.
-2. Manually validate the new Multicast in-app mock peer flow and decide whether the single-machine self-echo + peer-echo behavior needs clearer UX copy.
-3. Step through TCP / UDP / Multicast / Serial selection on both `Device Lab` and `Settings` with a real pointer session to confirm only the active transport panel remains visible.
-4. Validate with:
-   - interactive `win-x64` transport checks
-   - local UDP / Multicast loopback sends through the new mock card
-   - targeted `win-x86` spot-check only if a follow-up behavior tweak touches host/runtime-sensitive code
+1. Choose the smallest real consumer of `SerializerOptions.BitFieldSchema`, preferring config-backed inbound inspection/log enrichment over a WinUI schema editor or any transport change.
+2. If that consumer stays small and reviewable, thread the schema through one example/config surface while keeping `RawHex` as the active transport/session payload carrier.
+3. Revisit richer typed serializer/protocol options only if the first consumer exposes real pressure beyond the current optional schema seam.
 
 ## Stop / Reassess Conditions
-- If single-machine multicast produces confusing duplicate inbound lines, prefer clarifying status/log copy or documenting the expected behavior before redesigning the transport path.
-- If any collapsed transport panel still appears in UI Automation or the live UI when it should be hidden, inspect the binding/converter path before widening the layout change.
+- If the first consumer starts pulling both outbound schema editing and inbound inspection UI into the same slice, split the work and keep only one direction in scope.
+- If schema usage starts requiring variable-length payloads or non-integer field types, stop and record that as follow-up instead of stretching the current fixed-length signed/unsigned model.
+- If `SerializerOptions.BitFieldSchema` begins to force a broad options-hierarchy refactor, document the pressure and defer that refactor until after a concrete consumer proves it necessary.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -83,3 +83,57 @@
 - Decision: add the package version once in `Directory.Packages.props`, then reference it only from `CommLib.Unit.Tests` and `CommLib.Infrastructure.Tests` with `PrivateAssets=all`.
 - Why: this matches the package's actual execution model, keeps non-test projects free of irrelevant dependencies, and still gives the repo-wide coverage behavior the user is aiming for because all executable tests now support `--collect:"XPlat Code Coverage"`.
 - Consequences: future coverage collection commands should run at the test-project or solution test layer; if new test projects are added later, they should opt into `coverlet.collector` the same way.
+
+## 2026-04-03 - Use `gh` CLI fallback when the GitHub connector cannot create the PR
+- Context: after the branch was pushed, the GitHub connector's pull-request creation call returned `403 Resource not accessible by integration` for `parksanghoon-sys/commlib-hub`.
+- Decision: keep the connector as the preferred path, but fall back to authenticated `gh` CLI PR creation when connector permissions block the operation.
+- Why: this preserves the intended publish flow without stalling on integration-scope limitations that are outside the repository code itself.
+- Consequences: future publish steps can still complete end-to-end from this environment as long as `gh` remains installed and authenticated, even if connector PR-creation permissions stay limited.
+
+## 2026-04-06 - Put raw hex/bitfield payload support in the serializer/composer path, not the transport or framing layer
+- Context: a follow-up design request asked whether the project can support payloads expressed as raw hex and messages whose semantics live in byte/bit fields. The current codebase already separates `IProtocol` frame-boundary work from `ISerializer` payload shaping, and the WinUI example still composes outbound data as a plain-text body.
+- Decision: if this capability is implemented, keep `IProtocol` focused on frame extraction/encoding and add the new behavior under serializer/payload-codec plus message-composer/UI configuration layers.
+- Why: bitfield semantics belong to payload interpretation, not to transport or frame boundaries, and reusing the existing protocol/session pipeline is the smallest structurally correct change.
+- Consequences: the first implementation slice should target raw-hex payload roundtrips with focused serializer/factory/UI changes; declarative bitfield schema mapping should be added only after that smaller path is validated.
+
+## 2026-04-06 - Prefer a reusable binary-payload seam over a one-off `RawHex` serializer bolt-on
+- Context: a second design review found that adding only `RawHex` to the current `SerializerFactory` would work for one immediate use case, but the surrounding seams are still too closed: `SerializerOptions` and `ProtocolOptions` are flat classes, the factories are hard-coded switches, and most example/logging paths still assume `string Body`.
+- Decision: keep the overall work in the serializer/composer layer, but shape it around a reusable binary payload representation plus cleaner typed/polymorphic serializer and protocol options rather than a single special-case serializer.
+- Why: this gives the project a path for raw hex, future bitfield schema mapping, and additional device-specific codecs without repeatedly changing the same central classes and WinUI assumptions.
+- Consequences: the next implementation plan should likely start with option-model/factory seam cleanup plus a raw-binary message/formatter path, then add the first raw-hex codec on top of that seam.
+
+## 2026-04-06 - Start the raw-hex implementation with binary message contracts and a bridge serializer before WinUI compose-mode UI
+- Context: the user asked to continue implementation from the raw hex / bitfield design, but the current codebase still assumed text bodies in message models and display/logging paths. Jumping straight to WinUI mode selection without a binary-capable core contract would have pushed more serializer-specific branching into the app layer.
+- Decision: implement the first TDD slice as new binary-capable message contracts (`IBinaryMessagePayload` plus binary message models), a shared `MessagePayloadFormatter`, and a `RawHexSerializer` that can bridge both direct binary payloads and the current hex-text compose input style.
+- Why: this is the smallest structurally correct slice that unlocks raw payload roundtrips, keeps transport/protocol untouched, and gives the next WinUI step a real backend contract instead of a UI-only toggle with no binary message foundation.
+- Consequences: binary inbound payloads can now render safely in logs and examples, `SerializerFactory` can create `RawHex`, and the next step should focus on explicit WinUI composer/settings wiring plus end-to-end manual validation; schema-driven bitfield mapping remains deferred.
+
+## 2026-04-06 - Keep serializer choice fixed for the active session and treat mid-session selector edits as next-session changes
+- Context: the WinUI example now persists and exposes serializer choice, but `ConnectionManager` still creates the active serializer only during `ConnectAsync`. Letting the send path immediately obey a changed selector while connected would desynchronize UI composition from the already-open session serializer.
+- Decision: capture the serializer type from the connected `DeviceProfile` and compose outbound messages against that active serializer for the lifetime of the session. If the user changes the serializer selector while still connected, the new choice is stored for the next connect rather than mutating the live session behavior.
+- Why: this preserves protocol correctness with the smallest safe change and avoids pretending the session's framing/serialization contract can be hot-swapped after connection without a deliberate reconnect boundary.
+- Consequences: current sends stay aligned with the live session serializer, while a future UX refinement may still choose to disable the serializer selector during connection or surface a clearer "applies on next session" hint if operators find the current behavior ambiguous.
+
+## 2026-04-06 - Rotate raw-hex work onto its own feature branch instead of continuing on the merged WinUI branch
+- Context: the earlier WinUI localization/device-lab work was already merged through PR `#3`, but raw-hex serializer/composer development had started locally while still on `feat/winui-localization-foundation`.
+- Decision: move the ongoing raw-hex work onto `feat/rawhex-compose-flow` and continue future changes there.
+- Why: once the work expanded into a new feature area, keeping it on the old merged branch would blur scope, history, and review boundaries.
+- Consequences: future raw-hex and later bitfield-adjacent work should continue from the dedicated branch lineage unless a new feature split justifies another branch rotation.
+
+## 2026-04-06 - Keep WinUI async command continuations on the UI context when they update observable state
+- Context: during the live raw-hex TCP WinUI validation, connection succeeded and logs updated, but buttons such as `Send` remained disabled. The WinUI `MainViewModel` command handlers and `SettingsViewModel` save/reload handlers were awaiting service/store calls with `ConfigureAwait(false)` and then mutating observable properties/command state.
+- Decision: in WinUI command handlers that update observable UI state after awaiting, do not use `ConfigureAwait(false)`; let the continuation resume on the captured UI context.
+- Why: the WinUI layer owns button/status/property updates, and resuming those continuations off the UI context creates command-enable/state propagation bugs even when the underlying operation succeeded.
+- Consequences: service/infrastructure layers can still use `ConfigureAwait(false)` freely, but UI-facing command handlers should keep their post-await state changes on the UI context unless they explicitly marshal back through the dispatcher.
+
+## 2026-04-06 - Start bitfield support with an LSB-first payload convention and a low-level field codec
+- Context: the next requested direction after raw-hex validation was to begin thinking in bit units, but the repo still lacked even a minimal shared definition for named bit ranges or a proven read/write seam above raw payload bytes.
+- Decision: start with `BitFieldDefinition` plus `BitFieldCodec`, using the convention that `payload[0]` LSB is bit `0`. Support unsigned reads, signed reads via sign extension, and unsigned in-place writes up to 64 bits in this first slice.
+- Why: this is the smallest structurally correct foundation that can support future schema-backed compose/inspect work without dragging transport/protocol changes, UI schema editing, or multiple competing bit-numbering semantics into the first implementation.
+- Consequences: future schema-backed layers can reuse one proven low-level bit-addressing rule immediately, while alternate bit numbering and richer value types remain explicit follow-up decisions instead of implicit assumptions.
+
+## 2026-04-07 - Model the first schema-backed bitfield layer as payload metadata above `RawHex`, not as a new transport/protocol concern
+- Context: after the low-level `BitFieldDefinition` / `BitFieldCodec` slice landed, the repo still lacked a reusable schema model, schema validation, and a settings seam that could carry those definitions without widening into a WinUI schema editor or a transport rewrite.
+- Decision: add `BitFieldPayloadSchema` plus `BitFieldPayloadField`, `BitFieldScalarKind`, `BitFieldPayloadSchemaValidator`, and `BitFieldPayloadSchemaCodec` above the low-level codec, expose that schema through optional `SerializerOptions.BitFieldSchema`, and treat schema usage as valid only with `RawHex` in the current validator. Use `decimal` for compose assignments and inspect results so the first schema API can cover the full signed and unsigned 64-bit scalar range without introducing a heavier numeric abstraction yet.
+- Why: this is the smallest structurally correct way to create a reusable schema-backed compose/inspect seam that stays in the serializer/composer layer, keeps configuration binding straightforward, and avoids mixing schema semantics into transport or frame-boundary code.
+- Consequences: the project now has a config-friendly payload schema model and a validated compose/inspect helper that future UI or config-backed consumers can reuse directly; the next slice should choose one real consumer of `SerializerOptions.BitFieldSchema` before any broader typed serializer-options refactor or WinUI schema-editor work.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -434,3 +434,48 @@
 - [ ] 실행 중인 `win-x64` WinUI 앱에서 Multicast in-app mock 흐름을 손으로 검증하고, self-echo 중복 로그 UX 설명이 더 필요한지 판단
 - [ ] 실제 마우스 포인터 기준으로 `Device Lab` / `Settings` transport 전환 시 현재 transport 설정만 보이는지, 텍스트 입력 위 휠 스크롤이 자연스러운지 점검
 - [ ] 필요하면 README 또는 UI copy에 `Serial`은 외부 peer 필요, `Multicast`는 단일 머신에서 로그가 중복될 수 있다는 점을 더 분명히 남길지 결정
+
+### 4. 추가 업데이트
+- [x] `Directory.Build.props`, `Directory.Packages.props`를 추가해 공통 `Nullable` / `ImplicitUsings`와 NuGet 버전을 repo 루트에서 중앙 관리하도록 정리
+- [x] `coverlet.collector`를 `CommLib.Unit.Tests`, `CommLib.Infrastructure.Tests`에만 연결하고, 비테스트 프로젝트에는 넣지 않는 구조로 정리
+- [x] 오늘 WinUI follow-up 변경을 기능 단위 커밋 3개(`1601dbc`, `f21d5dd`, `bad9ee7`)로 분리 정리
+- [x] `feat/winui-localization-foundation` 브랜치를 원격 `commlib-hub`에 push하고 GitHub CLI fallback으로 PR #3을 생성
+- [x] 이후 GitHub 기준으로 PR #3 `[codex] localize and streamline the WinUI device lab` 이 `main`에 merge된 상태를 확인
+
+### 5. 추가 검증
+- [x] `dotnet build commlib-codex-full.sln` 통과
+- [x] `dotnet test commlib-codex-full.sln --no-build` 통과
+- [x] `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --collect:"XPlat Code Coverage"` 통과 및 Cobertura 산출물 생성 확인
+- [x] `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --collect:"XPlat Code Coverage"` 통과 및 Cobertura 산출물 생성 확인
+
+### 6. 후속 메모
+- [ ] 남은 UDP / Multicast manual validation과 transport panel 실포인터 점검은 merge 이후 기준으로 `main` 동기화 또는 새 작업 브랜치 정리 후 이어서 진행
+- [ ] `PROGRESS.md` 인코딩 정규화는 append-only 기록이 가능해진 현재도 여전히 별도 hygiene 작업으로 남아 있음
+
+## 2026-04-06
+
+### 1. 추가 업데이트
+- [x] raw-hex / bitfield 후속 작업을 merged 브랜치와 분리하기 위해 작업 브랜치를 `feat/rawhex-compose-flow`로 회전
+- [x] `IBinaryMessagePayload`, binary message models, `MessagePayloadFormatter`, `RawHexSerializer`, `SerializerFactory` `RawHex` 분기를 추가해 text-only 가정을 깨고 raw payload 기반을 마련
+- [x] WinUI 예제에 serializer 선택 저장/연결 경로와 `OutboundMessageComposer`를 붙여 `Device Lab` / `Settings`에서 `RawHex` compose 경로를 실제 세션 전송으로 연결
+- [x] `RawHexConnectionManagerRoundtripTests`를 추가해 실제 `ConnectionManager` + `TcpTransport` + `LengthPrefixedProtocol` + `RawHexSerializer` 경로에서 direct binary payload와 hex-text bridge roundtrip을 고정
+- [x] `win-x64` WinUI `Device Lab`에서 in-app mock TCP peer로 live raw-hex roundtrip을 확인하고, 연결 후 `Send`가 비활성으로 남던 회귀를 `MainViewModel`, `SettingsViewModel`의 UI-context continuation 복구로 수정
+- [x] `BitFieldDefinition`, `BitFieldCodec`, `BitFieldCodecTests`를 추가해 `payload[0]` LSB = bit `0` 규약의 bit-range read/write foundation을 TDD로 고정
+
+### 2. 추가 검증
+- [x] `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore --filter "FullyQualifiedName~MessagePayloadFormatterTests"`
+- [x] `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~RawHexSerializerTests"`
+- [x] `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~SerializerFactoryTests"`
+- [x] `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~RawHexConnectionManagerRoundtripTests"`
+- [x] `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore --filter "FullyQualifiedName~BitFieldCodecTests"`
+- [x] `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
+- [x] `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
+- [x] `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --no-restore`
+- [x] `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj --no-restore`
+- [x] `win-x64` UI Automation smoke에서 `Start Mock -> Connect -> Send`를 실행해 `Outbound message: id=321, body="DE AD BE EF"`와 `Inbound message: id=321, body="DE AD BE EF"`를 live log로 확인
+
+### 3. 후속 메모
+- [ ] `BitFieldDefinition` / `BitFieldCodec` 위에 schema-backed compose/inspect slice를 얹어 feature-level bitfield flow를 만들기
+- [ ] raw-hex / bitfield slice가 한 단계 더 정리된 뒤 UDP / Multicast / real-pointer WinUI manual validation을 재개하기
+- [ ] later device 계약이 pressure를 주기 전까지는 alternate bit numbering, richer scalar types, schema editor UI는 defer 유지
+- [ ] `PROGRESS.md`는 이번에도 기존 인코딩 혼합 위험 때문에 append-only로 기록했고, 별도 hygiene 작업으로 UTF-8 normalization이 필요

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,12 +1,19 @@
 # TODOS
 
 ## Current TODOs
-- [ ] Manually validate the new UDP in-app mock peer flow from the current `win-x64` WinUI app.
-- [ ] Manually validate the new Multicast in-app mock peer flow and decide whether the single-machine self-echo + peer-echo behavior needs clearer UX copy.
-- [ ] Step through TCP / UDP / Multicast / Serial selection on both `Device Lab` and `Settings` with a real pointer session and confirm only the selected transport panel stays visible.
-- [ ] Re-check transition feel, wheel-scroll behavior, and live-log manual scrolling only if the transport-panel/manual mock pass exposes a concrete regression.
+- [ ] Add the first real consumer of `SerializerOptions.BitFieldSchema`, preferring config-backed inbound inspection/log enrichment over a WinUI schema editor or any transport/protocol change.
 
 ## Deferred Backlog
+
+### [P1_SOON] Resume the older UDP / Multicast / real-pointer WinUI validation pass after the raw-hex composer work
+- What remains: re-run the manual UDP and Multicast mock endpoint checks, step through TCP / UDP / Multicast / Serial panel switching on both `Device Lab` and `Settings`, and only re-check transition feel / wheel-scroll / live-log manual scrolling if that pass surfaces a concrete regression.
+- Why deferred: raw-hex TCP is now wired, covered by automated lower-stack tests, validated through a live WinUI roundtrip, and the active implementation priority has shifted to the first bitfield foundation slice.
+- Objective: close the remaining interactive WinUI confidence gaps without mixing them into the current serializer-layer implementation slice.
+- Relevant context: transport-panel collapsing, live-log auto-follow, in-app mock peers, and the earlier TCP automation smoke are already in place; the remaining gaps are real-pointer confirmation plus UDP/Multicast behavior in the live app.
+- Scope: `examples/CommLib.Examples.WinUI/Views/DeviceLabView.cs`, `examples/CommLib.Examples.WinUI/Views/SettingsView.cs`, `examples/CommLib.Examples.WinUI/ViewModels/MainViewModel.cs`, `examples/CommLib.Examples.WinUI/Services/LocalMockEndpointService.cs`, and any resulting docs/status text.
+- Current status: TCP mock flow already has earlier automation smoke coverage, the raw-hex TCP transport/session path now has focused infrastructure roundtrip coverage, and a live WinUI raw-hex TCP pass is complete. UDP / Multicast and real-pointer confirmation are still manual-only.
+- Known blockers/open questions: whether multicast still needs clearer UX copy once the broader live pass happens, and whether any real-pointer issue appears that did not show up in automation.
+- Most natural next step: run one live `Device Lab` session that focuses on UDP, Multicast, panel switching, and real-pointer behavior rather than repeating the now-covered raw-hex TCP path.
 
 ### [P1_SOON] Clarify single-machine multicast mock UX if duplicate inbound lines feel confusing
 - What remains: decide whether the new in-app multicast mock flow needs stronger status/log copy, a dedicated note in the UI, or a small behavior tweak for one-machine validation sessions.
@@ -48,7 +55,34 @@
 - Known blockers/open questions: whether the file contains mixed UTF-8 and legacy code-page bytes, and what normalization path preserves the current readable Korean content best.
 - Most natural next step: back up the file, detect the dominant encoding per corrupted section, and rewrite once with a verified UTF-8 result so future updates can use normal in-place editing again.
 
+### [P1_SOON] Extend the binary-capable serializer path toward future bitfield schema support without rewriting the transport/protocol layers
+- What remains: apply the new schema layer to at least one real runtime consumer, then decide from that concrete usage whether later phases truly need richer typed serializer/protocol options plus broader bitfield-aware schema mapping for byte/bit-oriented devices.
+- Why deferred: the repo now has raw-hex transport/session validation, a low-level bitfield codec, a schema model, overlap/range validation, and a serializer-adjacent schema setting seam, but it still does not use that schema in a real config-backed or UI-backed compose/inspect path.
+- Objective: support devices whose payload contract is defined in bytes and bit ranges while preserving the existing transport, session, and frame-boundary architecture.
+- Relevant context: `IProtocol` still owns frame boundaries only, which remains the intended boundary. The repo now has `IBinaryMessagePayload`, binary message models, `MessagePayloadFormatter`, `RawHexSerializer`, `OutboundMessageComposer`, persisted serializer selection in the WinUI example, `RawHexConnectionManagerRoundtripTests` covering both direct binary payloads and the hex-text bridge over the real TCP/session stack, `BitFieldDefinition`/`BitFieldCodec`, plus the new `BitFieldPayloadSchema` / `BitFieldPayloadSchemaValidator` / `BitFieldPayloadSchemaCodec` layer and optional `SerializerOptions.BitFieldSchema`.
+- Scope: `src/CommLib.Domain/Configuration/SerializerOptions.cs`, `src/CommLib.Domain/Configuration/ProtocolOptions.cs`, `src/CommLib.Domain/Messaging`, `src/CommLib.Application/Configuration/DeviceProfileMapper.cs`, `src/CommLib.Application/Configuration/DeviceProfileValidator.cs`, `src/CommLib.Infrastructure/Factories`, any future serializer/schema support under `src/CommLib.Infrastructure`, WinUI composer/settings files under `examples/CommLib.Examples.WinUI`, and focused tests/docs.
+- Current status: the repository now supports binary payload message representation, formatter-based binary display, `RawHex` serializer creation, outbound hex parsing, inbound binary message deserialization, persisted WinUI serializer choice, automated raw-hex TCP roundtrip coverage, a live WinUI raw-hex TCP proof, low-level bitfield read/write helpers, and a validated fixed-length signed/unsigned schema-backed compose/inspect layer. The remaining gap before widening is a real consumer that uses the schema at runtime.
+- Known blockers/open questions: whether the first real consumer should be inbound inspection/log enrichment or a config-backed outbound helper, whether the current optional schema property is enough or will later pressure a richer typed serializer-options model, whether inbound raw payloads should stay formatter-based or gain richer UI treatment, and how much schema-editing UX the WinUI example should expose in the first bitfield-aware phase.
+- Most natural next step: thread `SerializerOptions.BitFieldSchema` into one no-UI consumer, with config-backed inbound inspection/log enrichment preferred over a full schema editor.
+
+### [P2_LATER] Consider alternate bit numbering and richer scalar types after the first schema-backed bitfield slice
+- What remains: evaluate whether later devices need MSB-first bit numbering, scaled numeric fields, enums, floats, BCD, or packed string helpers beyond the current unsigned/signed integer foundation.
+- Why deferred: the current repo needed a single evidence-backed bitfield convention first, and widening into multiple numbering/data-type semantics before the schema layer exists would add more ambiguity than value.
+- Objective: keep the first bitfield implementation small and reviewable while leaving a clear slot for broader device-specific field semantics later.
+- Relevant context: the current `BitFieldCodec` uses the convention `payload[0]` LSB = bit `0`, supports up to 64-bit scalar reads, and writes unsigned scalar values in place.
+- Scope: `src/CommLib.Domain/Messaging/BitFieldDefinition.cs`, `src/CommLib.Domain/Messaging/BitFieldCodec.cs`, any future schema/value-type files under `src/CommLib.Domain` or `src/CommLib.Application`, and focused tests/docs.
+- Current status: the low-level bitfield seam exists and is covered by tests, but alternative numbering and richer value semantics are intentionally out of scope for this first slice.
+- Known blockers/open questions: whether real target devices describe bits as LSB-first or MSB-first, and which non-integer field types actually matter enough to justify first-class support.
+- Most natural next step: wait until the schema-backed compose/inspect layer exists and at least one real device contract pressures a broader numbering or value-type surface.
+
 ## Completed
+- [x] 2026-04-07: added the first schema-backed bitfield slice with `BitFieldPayloadSchema`, `BitFieldPayloadField`, `BitFieldScalarKind`, `BitFieldPayloadSchemaValidator`, `BitFieldPayloadSchemaCodec`, optional `SerializerOptions.BitFieldSchema`, and schema-based `OutboundMessageComposer` support; validated with full unit tests, full infrastructure tests, and a solution build.
+- [x] 2026-04-06: added the first bitfield foundation slice with `BitFieldDefinition` and `BitFieldCodec`, covering unsigned reads, signed reads, and unsigned writes against named bit ranges using the `payload[0]` LSB = bit `0` convention; verified with focused `BitFieldCodecTests` plus full unit and infrastructure test runs.
+- [x] 2026-04-06: completed a live `win-x64` WinUI raw-hex TCP roundtrip through the in-app mock endpoint by launching the app in `RawHex` mode, invoking `Start Mock`, `Connect`, and `Send`, and confirming matching outbound/inbound `DE AD BE EF` log entries for message id `321`; fixed the UI command-state regression that had kept `Send` disabled after connect by removing `ConfigureAwait(false)` from WinUI async command handlers that update observable state.
+- [x] 2026-04-06: added `RawHexConnectionManagerRoundtripTests` to lock the real TCP `ConnectionManager`/`LengthPrefixedProtocol`/`RawHexSerializer` roundtrip for both direct binary payloads and the existing hex-text bridge; verified with the focused test filter and a full `CommLib.Infrastructure.Tests` run.
+- [x] 2026-04-06: wired serializer choice through the WinUI example by persisting `MessageComposer.SerializerType`, adding serializer choice state/UI on `Device Lab` and `Settings`, introducing `OutboundMessageComposer`, switching the session send path to composed `IMessage`, and surfacing localized raw-hex validation errors; verified with unit tests, infrastructure tests, and WinUI/console builds.
+- [x] 2026-04-06: established the first raw-hex foundation slice with `IBinaryMessagePayload`, binary message models, `MessagePayloadFormatter`, `RawHexSerializer`, `SerializerFactory` support for `RawHex`, and formatter-based binary payload rendering in WinUI session logs plus the console example; verified with unit tests, infrastructure tests, and example builds.
+- [x] 2026-04-03: split the day’s work into three local commits (`1601dbc`, `f21d5dd`, `bad9ee7`), pushed `feat/winui-localization-foundation`, created PR `#3`, and confirmed that GitHub now shows the PR as merged into `main`.
 - [x] 2026-04-03: added `coverlet.collector` to both test projects through `Directory.Packages.props` and verified `XPlat Code Coverage` output generation for unit and infrastructure tests.
 - [x] 2026-04-03: centralized shared MSBuild defaults into `Directory.Build.props` and moved package versions into `Directory.Packages.props`, removing inline package-version declarations from the project files.
 - [x] 2026-04-03: re-validated the repo after central package management with `dotnet build commlib-codex-full.sln` and `dotnet test commlib-codex-full.sln --no-build`.

--- a/docs/current-plan.md
+++ b/docs/current-plan.md
@@ -1,44 +1,60 @@
 # Current Plan
 
 ## Date
-- 2026-04-03
+- 2026-04-07
 
 ## Current Scope
-- WinUI example follow-up after localization foundation, wheel-scroll forwarding, restored `win-x64` default startup, conservative page transitions, the new scrollable auto-follow live log, the live `DeviceLabTheme` hookup, the new in-app mock peer path, and repo-level package/version centralization
-- Next priority: validate the remaining UDP/Multicast mock flows and confirm transport-panel visibility in a real pointer session
+- Continue the raw hex / future bitfield support design by turning the new schema-backed payload layer into one real consumer while keeping transport/protocol behavior unchanged
+- Keep transport/protocol behavior unchanged and still stop short of a WinUI schema editor or transport/protocol rewrites for this cycle
 
 ## Confirmed State
-- Branch is now `feat/winui-localization-foundation`.
-- English/Korean language mode is persisted in the WinUI example settings.
-- Shell, Device Lab, Settings, and connection/session status copy now go through the example localizer.
-- `PointerWheelScrollBridge` forwards text-input wheel events to the page `ScrollViewer` in `DeviceLab` and `Settings`.
-- `AppShellView` animates page switches with a conservative fade + horizontal slide while keeping the existing dual-host layout.
-- `DeviceLabView` live log keeps its own scrolling and auto-follows the newest log entry.
-- The live-log follower now caches the inner `ScrollViewer` and explicitly scrolls it to the document end after each text update.
-- `DeviceLabTheme` is now actually consumed by `AppShellView`, `DeviceLabView`, and `SettingsView` for shared backgrounds, card chrome, and typography instead of sitting unused.
-- `DeviceLabView` and `SettingsView` now show only the currently selected transport panel instead of every transport preset at once.
-- `DeviceLabView` now exposes an in-app `Mock Endpoint` card:
-  - TCP and UDP pin loopback-friendly settings and start local echo peers
-  - Multicast joins the selected group locally and replies back to the sender port for one-machine checks
-  - Serial still requires an external paired COM environment
-- `Directory.Build.props` now owns the shared `Nullable` / `ImplicitUsings` defaults, and `Directory.Packages.props` centrally manages the repo's package versions.
-- The two test projects now reference `coverlet.collector` through the centralized package version file, and local `XPlat Code Coverage` runs produced Cobertura XML outputs successfully.
-- The main WinUI example files now include Korean comments for non-obvious bootstrap, transition, logging, session, and mock-peer logic.
+- `AGENT.md` is the active repository rules file; `AGENT_RULES.md` is not present at the repo root.
+- Branch remains `feat/rawhex-compose-flow`.
+- GitHub PR `#3` for the earlier WinUI line of work is already merged into `main`, and the ongoing raw-hex / bitfield work stays isolated on the dedicated feature branch.
+- The WinUI example follow-up from the prior cycle remains intact:
+  - localized shell / Device Lab / Settings / status copy
+  - page text-input wheel forwarding
+  - conservative page transitions
+  - scrollable auto-follow live log
+  - active `DeviceLabTheme` usage
+  - transport-panel collapsing
+  - in-app TCP / UDP / Multicast mock endpoint support
+  - repo-level package/build centralization
+- The raw-hex library/application surface from 2026-04-06 remains in place:
+  - `IBinaryMessagePayload`
+  - `BinaryMessageModel`, `BinaryRequestMessageModel`, and `BinaryResponseMessageModel`
+  - `MessagePayloadFormatter`
+  - `RawHexSerializer`
+  - `SerializerFactory` support for `RawHex`
+  - WinUI serializer selection and localized raw-hex validation
+  - automated transport/session raw-hex roundtrip coverage
+  - a live WinUI raw-hex TCP roundtrip proof
+- The low-level bitfield foundation from 2026-04-06 remains in place:
+  - `BitFieldDefinition`
+  - `BitFieldCodec`
+  - the `payload[0]` LSB = bit `0` convention
+- The first schema-backed bitfield slice completed on 2026-04-07:
+  - `BitFieldPayloadSchema`, `BitFieldPayloadField`, and `BitFieldScalarKind`
+  - `BitFieldFieldAssignment` and `BitFieldFieldValue`
+  - `BitFieldPayloadSchemaValidator`
+  - `BitFieldPayloadSchemaCodec` for named-field compose/inspect above `BitFieldCodec`
+  - optional `SerializerOptions.BitFieldSchema`
+  - `DeviceProfileValidator` enforcement that schema usage is currently valid only with `RawHex`
+  - `OutboundMessageComposer` support for schema-driven binary payload composition
+- The first schema API uses `decimal` for compose assignments and inspect results so the layer stays simple while still covering signed and unsigned 64-bit scalar values.
 - Verification completed with:
-  - `dotnet build commlib-codex-full.sln`
-  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
-  - `dotnet test commlib-codex-full.sln`
-  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --collect:"XPlat Code Coverage"`
-  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --collect:"XPlat Code Coverage"`
-  - a `win-x64` UI Automation smoke that found the localized window, confirmed the UDP-only `Local Port` label was hidden on the default TCP screen, invoked `Start Mock`, and completed a raw TCP echo roundtrip to `127.0.0.1:7001`
-  - a follow-up `win-x64` UI Automation smoke that sent 12 TCP messages and confirmed the visible log range still reached the document end after the explicit end-scroll change
-- `PROGRESS.md` still needs encoding normalization before safe in-place automated edits, although a UTF-8 append path worked for the 2026-04-03 daily log.
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
+  - `dotnet build commlib-codex-full.sln --no-restore`
+- `PROGRESS.md` still needs separate encoding normalization before normal in-place automation is safe.
 
 ## Next Work Unit
-1. Manually validate UDP and Multicast through the new in-app mock peer card.
-2. Confirm transport-panel visibility while switching TCP / UDP / Multicast / Serial in both `Device Lab` and `Settings`.
-3. Only if the multicast UX is too confusing on one machine, adjust the status copy or behavior with the smallest safe change.
+1. Choose the smallest real consumer of `SerializerOptions.BitFieldSchema`, preferring config-backed inbound inspection/log enrichment over a WinUI schema editor or any transport change.
+2. If that consumer stays small and reviewable, thread the schema through one example/config surface while keeping `RawHex` as the current payload carrier.
+3. Revisit richer typed serializer/protocol options only if the first consumer exposes real pressure beyond the current optional schema seam.
 
 ## Deferred / Not For This Step
-- `PROGRESS.md` full encoding normalization as separate repo hygiene work so future in-place edits do not need append-only handling.
+- Resume the older UDP / Multicast / pointer-session manual validation pass after the current serializer/composer work makes the next manual check more valuable.
+- `PROGRESS.md` full encoding normalization stays separate repo hygiene work.
 - Full templated-control theming stays deferred until the WinUI default-style key coverage is mapped safely for this app shape.
+- A WinUI schema editor stays deferred until the lower schema-backed layer has a real consumer and review feedback.

--- a/examples/CommLib.Examples.Console/Program.cs
+++ b/examples/CommLib.Examples.Console/Program.cs
@@ -342,7 +342,7 @@ internal static class ExampleConsole
 
     private static string DescribeMessage(IMessage message)
     {
-        var body = message is IMessageBody bodyMessage ? bodyMessage.Body : string.Empty;
+        var body = MessagePayloadFormatter.FormatBody(message);
         return message switch
         {
             IResponseMessage response => $"response id={message.MessageId}, correlation={response.CorrelationId}, success={response.IsSuccess}, body=\"{body}\"",

--- a/examples/CommLib.Examples.WinUI/Models/DeviceLabAppSettings.cs
+++ b/examples/CommLib.Examples.WinUI/Models/DeviceLabAppSettings.cs
@@ -1,3 +1,5 @@
+using CommLib.Domain.Configuration;
+
 namespace CommLib.Examples.WinUI.Models;
 
 public sealed class DeviceLabAppSettings
@@ -37,6 +39,8 @@ public sealed class SessionAppSettings
 
 public sealed class MessageComposerAppSettings
 {
+    public string SerializerType { get; set; } = SerializerTypes.AutoBinary;
+
     public string OutboundMessageId { get; set; } = "100";
 
     public string OutboundBody { get; set; } = "hello from the mvvm winui lab";

--- a/examples/CommLib.Examples.WinUI/Models/DeviceLabAppSettings.cs
+++ b/examples/CommLib.Examples.WinUI/Models/DeviceLabAppSettings.cs
@@ -1,4 +1,5 @@
 using CommLib.Domain.Configuration;
+using CommLib.Domain.Messaging;
 
 namespace CommLib.Examples.WinUI.Models;
 
@@ -40,6 +41,8 @@ public sealed class SessionAppSettings
 public sealed class MessageComposerAppSettings
 {
     public string SerializerType { get; set; } = SerializerTypes.AutoBinary;
+
+    public BitFieldPayloadSchema? BitFieldSchema { get; set; }
 
     public string OutboundMessageId { get; set; } = "100";
 

--- a/examples/CommLib.Examples.WinUI/README.md
+++ b/examples/CommLib.Examples.WinUI/README.md
@@ -1,6 +1,6 @@
 # CommLib WinUI Device Lab
 
-`CommLib.Examples.WinUI` is a WinUI 3 desktop example that lets you connect to a real TCP, UDP, multicast, or serial endpoint, send a `MessageModel`, and watch inbound traffic in a live log.
+`CommLib.Examples.WinUI` is a WinUI 3 desktop example that lets you connect to a real TCP, UDP, multicast, or serial endpoint, send outbound traffic with either the text-oriented `AutoBinary` serializer or the new `RawHex` mode, and watch inbound traffic in a live log.
 
 ## Architecture
 
@@ -15,7 +15,7 @@
 
 - `ConnectionManager` session lifecycle
 - Real `TcpTransport`, `UdpTransport`, `MulticastTransport`, and `SerialTransport`
-- Length-prefixed framing with the `AutoBinary` serializer
+- Length-prefixed framing with selectable `AutoBinary` or `RawHex` serialization
 - Shared settings state across the `Device Lab` and `Settings` pages
 - JSON-backed app configuration in `examples/CommLib.Examples.WinUI/appsettings.json`
 
@@ -28,7 +28,8 @@ dotnet run --project examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.cspr
 
 ## Notes
 
-- The peer device or test server must speak the same `LengthPrefixed + AutoBinary` format used by the library examples.
+- The peer device or test server must speak the same `LengthPrefixed + serializer` combination currently selected in the app.
+- `AutoBinary` keeps the existing text-body example format, while `RawHex` sends whitespace-tolerant hexadecimal byte pairs as the raw payload.
 - TCP and UDP expect a reachable remote endpoint.
 - Multicast receive/send requires the same group and port on both sides.
 - Serial requires a real COM port, a paired virtual port, or hardware loopback wiring.

--- a/examples/CommLib.Examples.WinUI/README.md
+++ b/examples/CommLib.Examples.WinUI/README.md
@@ -30,6 +30,7 @@ dotnet run --project examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.cspr
 
 - The peer device or test server must speak the same `LengthPrefixed + serializer` combination currently selected in the app.
 - `AutoBinary` keeps the existing text-body example format, while `RawHex` sends whitespace-tolerant hexadecimal byte pairs as the raw payload.
+- `RawHex` can now also load an optional `messageComposer.bitFieldSchema` from `appsettings.json`; when present, the live log appends decoded field summaries for inbound/outbound binary payloads. There is still no in-app schema editor, so this schema is currently JSON-managed only.
 - TCP and UDP expect a reachable remote endpoint.
 - Multicast receive/send requires the same group and port on both sides.
 - Serial requires a real COM port, a paired virtual port, or hardware loopback wiring.
@@ -38,3 +39,41 @@ dotnet run --project examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.cspr
 - The in-app mock peer path covers TCP, UDP, and Multicast on loopback; Serial still stays external because it needs a paired COM environment.
 - The sample now defaults to `win-x64` again because the current branch state no longer reproduces the earlier local `Microsoft.UI.Xaml.dll` startup fault; `-r win-x86` remains available if you need to compare runtimes.
 - The default `appsettings.json` is copied to the output folder on build and then reused as the runtime settings file.
+
+## RawHex Schema Example
+
+Use a `RawHex` serializer plus `messageComposer.bitFieldSchema` when you want the live log to append decoded field summaries for binary payloads:
+
+```json
+{
+  "messageComposer": {
+    "serializerType": "RawHex",
+    "bitFieldSchema": {
+      "payloadLengthBytes": 4,
+      "fields": [
+        {
+          "name": "prefix",
+          "bitOffset": 0,
+          "bitLength": 8
+        },
+        {
+          "name": "register",
+          "bitOffset": 8,
+          "bitLength": 16,
+          "endianness": "BigEndian"
+        },
+        {
+          "name": "tail",
+          "bitOffset": 24,
+          "bitLength": 8
+        }
+      ]
+    },
+    "outboundMessageId": "100",
+    "outboundBody": "AA 12 34 7F"
+  }
+}
+```
+
+- The schema is used for log enrichment only in this slice; it does not add an in-app schema editor or change the transport/protocol boundary.
+- `BigEndian` is currently supported only for byte-aligned multi-byte fields whose lengths are whole-byte multiples.

--- a/examples/CommLib.Examples.WinUI/Services/AppLocalizer.cs
+++ b/examples/CommLib.Examples.WinUI/Services/AppLocalizer.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using CommLib.Domain.Configuration;
 using CommLib.Examples.WinUI.Models;
 
 namespace CommLib.Examples.WinUI.Services;
@@ -53,6 +54,7 @@ public sealed class AppLocalizer : IAppLocalizer
         ["field.readBufferSize"] = "Read Buffer Size",
         ["field.writeBufferSize"] = "Write Buffer Size",
         ["field.messageId"] = "Message Id",
+        ["field.serializer"] = "Serializer",
         ["field.body"] = "Body",
         ["check.noDelay"] = "Disable Nagle (NoDelay)",
         ["check.loopback"] = "Enable loopback",
@@ -133,6 +135,7 @@ public sealed class AppLocalizer : IAppLocalizer
         ["session.event.operationFailed.title"] = "Connection operation failed",
         ["session.event.operationFailed.message"] = "{0} {1}: {2}",
         ["session.error.noActiveSession"] = "No active device session exists.",
+        ["composer.error.invalidRawHex"] = "Raw hex mode expects hexadecimal byte pairs like \"DE AD BE EF\".",
         ["transport.detail.tcp"] = "TCP {0}:{1}",
         ["transport.detail.udp"] = "UDP local={0}, remote={1}:{2}",
         ["transport.detail.multicast"] = "Multicast {0}:{1}",
@@ -186,6 +189,7 @@ public sealed class AppLocalizer : IAppLocalizer
         ["field.readBufferSize"] = "읽기 버퍼 크기",
         ["field.writeBufferSize"] = "쓰기 버퍼 크기",
         ["field.messageId"] = "메시지 ID",
+        ["field.serializer"] = "직렬화기",
         ["field.body"] = "본문",
         ["check.noDelay"] = "네이글 비활성화(NoDelay)",
         ["check.loopback"] = "루프백 사용",
@@ -266,6 +270,7 @@ public sealed class AppLocalizer : IAppLocalizer
         ["session.event.operationFailed.title"] = "연결 작업 실패",
         ["session.event.operationFailed.message"] = "{0} {1}: {2}",
         ["session.error.noActiveSession"] = "현재 활성 디바이스 세션이 없습니다.",
+        ["composer.error.invalidRawHex"] = "Raw hex 모드는 \"DE AD BE EF\" 같은 16진수 바이트 쌍이 필요합니다.",
         ["transport.detail.tcp"] = "TCP {0}:{1}",
         ["transport.detail.udp"] = "UDP 로컬={0}, 원격={1}:{2}",
         ["transport.detail.multicast"] = "멀티캐스트 {0}:{1}",
@@ -359,6 +364,30 @@ public sealed class AppLocalizer : IAppLocalizer
             (_, TransportKind.Multicast) => "Group broadcast traffic",
             (_, TransportKind.Serial) => "COM and loopback links",
             _ => kind.ToString()
+        };
+    }
+
+    public string GetSerializerLabel(string serializerType)
+    {
+        return (CurrentLanguage, serializerType) switch
+        {
+            (AppLanguageMode.Korean, SerializerTypes.AutoBinary) => "텍스트 (AutoBinary)",
+            (AppLanguageMode.Korean, SerializerTypes.RawHex) => "Raw Hex",
+            (_, SerializerTypes.AutoBinary) => "Text (AutoBinary)",
+            (_, SerializerTypes.RawHex) => "Raw Hex",
+            _ => serializerType
+        };
+    }
+
+    public string GetSerializerSubtitle(string serializerType)
+    {
+        return (CurrentLanguage, serializerType) switch
+        {
+            (AppLanguageMode.Korean, SerializerTypes.AutoBinary) => "UTF-8 본문을 현재 예제 serializer 형식으로 보냅니다.",
+            (AppLanguageMode.Korean, SerializerTypes.RawHex) => "공백 허용 16진수 바이트를 raw payload로 보냅니다.",
+            (_, SerializerTypes.AutoBinary) => "Sends UTF-8 body text through the current example serializer format.",
+            (_, SerializerTypes.RawHex) => "Sends whitespace-tolerant hexadecimal bytes as the raw payload.",
+            _ => serializerType
         };
     }
 

--- a/examples/CommLib.Examples.WinUI/Services/AppLocalizer.cs
+++ b/examples/CommLib.Examples.WinUI/Services/AppLocalizer.cs
@@ -125,6 +125,8 @@ public sealed class AppLocalizer : IAppLocalizer
         ["session.log.outbound.message"] = "id={0}, body=\"{1}\"",
         ["session.log.inbound.title"] = "Inbound message",
         ["session.log.inbound.message"] = "id={0}, body=\"{1}\"",
+        ["session.payload.fieldsSuffix"] = "fields[{0}]",
+        ["session.payload.schemaErrorSuffix"] = "schema decode failed: {0}",
         ["session.log.receiveLoopStopped.title"] = "Receive loop stopped",
         ["session.event.connectAttempt.title"] = "Connect attempt",
         ["session.event.connectAttempt.message"] = "{0} ({1}/{2})",
@@ -275,7 +277,9 @@ public sealed class AppLocalizer : IAppLocalizer
         ["transport.detail.udp"] = "UDP 로컬={0}, 원격={1}:{2}",
         ["transport.detail.multicast"] = "멀티캐스트 {0}:{1}",
         ["transport.detail.serial"] = "시리얼 {0} @ {1}",
-        ["transport.detail.generic"] = "전송 {0}"
+        ["transport.detail.generic"] = "전송 {0}",
+        ["session.payload.fieldsSuffix"] = "\uD544\uB4DC[{0}]",
+        ["session.payload.schemaErrorSuffix"] = "\uC2A4\uD0A4\uB9C8 \uD574\uC11D \uC2E4\uD328: {0}"
     };
 
     private AppLanguageMode _currentLanguage;

--- a/examples/CommLib.Examples.WinUI/Services/DeviceLabSessionService.cs
+++ b/examples/CommLib.Examples.WinUI/Services/DeviceLabSessionService.cs
@@ -22,6 +22,7 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
     private CancellationTokenSource? _receiveLoopCts;
     private Task? _receiveLoopTask;
     private string? _connectedDeviceId;
+    private BitFieldPayloadSchema? _activeBitFieldSchema;
     private bool _hasState;
     private bool _isConnectedState;
     private string _statusTextKey = "session.state.disconnected";
@@ -75,6 +76,7 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
 
             _manager = manager;
             _connectedDeviceId = profile.DeviceId;
+            _activeBitFieldSchema = profile.Serializer.BitFieldSchema;
             _receiveLoopCts = new CancellationTokenSource();
             // 실제 수신은 백그라운드 루프가 담당하고, 결과만 log/state 이벤트로 ViewModel에 흘려보낸다.
             _receiveLoopTask = Task.Run(() => ReceiveLoopAsync(profile.DeviceId, _receiveLoopCts.Token));
@@ -133,7 +135,7 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
             }
 
             await _manager.SendAsync(_connectedDeviceId, message, cancellationToken).ConfigureAwait(false);
-            var body = MessagePayloadFormatter.FormatBody(message);
+            var body = FormatMessageBodyForLog(message);
             EmitLocalizedLog(
                 LogSeverity.Info,
                 "session.log.outbound.title",
@@ -176,7 +178,7 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
                 }
 
                 var message = await manager.ReceiveAsync(deviceId, cancellationToken).ConfigureAwait(false);
-                var body = MessagePayloadFormatter.FormatBody(message);
+                var body = FormatMessageBodyForLog(message);
                 EmitLocalizedLog(
                     LogSeverity.Success,
                     "session.log.inbound.title",
@@ -250,11 +252,13 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
             {
                 _manager = null;
                 _connectedDeviceId = null;
+                _activeBitFieldSchema = null;
             }
         }
         else
         {
             _connectedDeviceId = null;
+            _activeBitFieldSchema = null;
         }
 
         if (emitOfflineState)
@@ -276,6 +280,23 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
     private void EmitLocalizedLog(LogSeverity severity, string titleKey, string messageKey, params object?[] args)
     {
         EmitLog(severity, _localizer.Get(titleKey), _localizer.Format(messageKey, args));
+    }
+
+    private string FormatMessageBodyForLog(IMessage message)
+    {
+        var body = MessagePayloadFormatter.FormatBody(message);
+
+        if (MessagePayloadFormatter.TryFormatBitFieldSummary(message, _activeBitFieldSchema, out var summary, out var error))
+        {
+            return AppendPayloadSuffix(body, _localizer.Format("session.payload.fieldsSuffix", summary));
+        }
+
+        if (!string.IsNullOrWhiteSpace(error))
+        {
+            return AppendPayloadSuffix(body, _localizer.Format("session.payload.schemaErrorSuffix", error));
+        }
+
+        return body;
     }
 
     private void SetState(
@@ -321,6 +342,18 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
             SerialTransportOptions serial => ("transport.detail.serial", [serial.PortName ?? string.Empty, serial.BaudRate]),
             _ => ("transport.detail.generic", [transport.Type ?? string.Empty])
         };
+    }
+
+    private static string AppendPayloadSuffix(string body, string suffix)
+    {
+        if (string.IsNullOrWhiteSpace(suffix))
+        {
+            return body;
+        }
+
+        return string.IsNullOrEmpty(body)
+            ? suffix
+            : $"{body} | {suffix}";
     }
 
     private sealed class SessionConnectionEventSink(DeviceLabSessionService owner) : IConnectionEventSink

--- a/examples/CommLib.Examples.WinUI/Services/DeviceLabSessionService.cs
+++ b/examples/CommLib.Examples.WinUI/Services/DeviceLabSessionService.cs
@@ -121,7 +121,7 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
         }
     }
 
-    public async Task SendAsync(ushort messageId, string body, CancellationToken cancellationToken = default)
+    public async Task SendAsync(IMessage message, CancellationToken cancellationToken = default)
     {
         await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
 
@@ -132,13 +132,13 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
                 throw new InvalidOperationException(_localizer.Get("session.error.noActiveSession"));
             }
 
-            var message = new MessageModel(messageId, body);
             await _manager.SendAsync(_connectedDeviceId, message, cancellationToken).ConfigureAwait(false);
+            var body = MessagePayloadFormatter.FormatBody(message);
             EmitLocalizedLog(
                 LogSeverity.Info,
                 "session.log.outbound.title",
                 "session.log.outbound.message",
-                messageId,
+                message.MessageId,
                 body);
         }
         finally
@@ -176,7 +176,7 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
                 }
 
                 var message = await manager.ReceiveAsync(deviceId, cancellationToken).ConfigureAwait(false);
-                var body = message is IMessageBody bodyMessage ? bodyMessage.Body : string.Empty;
+                var body = MessagePayloadFormatter.FormatBody(message);
                 EmitLocalizedLog(
                     LogSeverity.Success,
                     "session.log.inbound.title",

--- a/examples/CommLib.Examples.WinUI/Services/IAppLocalizer.cs
+++ b/examples/CommLib.Examples.WinUI/Services/IAppLocalizer.cs
@@ -20,5 +20,9 @@ public interface IAppLocalizer
 
     string GetTransportSubtitle(TransportKind kind);
 
+    string GetSerializerLabel(string serializerType);
+
+    string GetSerializerSubtitle(string serializerType);
+
     string GetLanguageLabel(AppLanguageMode mode);
 }

--- a/examples/CommLib.Examples.WinUI/Services/IDeviceLabSessionService.cs
+++ b/examples/CommLib.Examples.WinUI/Services/IDeviceLabSessionService.cs
@@ -1,4 +1,5 @@
 using CommLib.Domain.Configuration;
+using CommLib.Domain.Messaging;
 using CommLib.Examples.WinUI.Models;
 
 namespace CommLib.Examples.WinUI.Services;
@@ -13,5 +14,5 @@ public interface IDeviceLabSessionService : IAsyncDisposable
 
     Task DisconnectAsync(CancellationToken cancellationToken = default);
 
-    Task SendAsync(ushort messageId, string body, CancellationToken cancellationToken = default);
+    Task SendAsync(IMessage message, CancellationToken cancellationToken = default);
 }

--- a/examples/CommLib.Examples.WinUI/ViewModels/DeviceLabSettingsViewModel.cs
+++ b/examples/CommLib.Examples.WinUI/ViewModels/DeviceLabSettingsViewModel.cs
@@ -1,3 +1,4 @@
+using CommLib.Domain.Configuration;
 using CommLib.Examples.WinUI.Models;
 using CommLib.Examples.WinUI.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -14,6 +15,7 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
     private string _outboundMessageId = "100";
     private string _outboundBody = "hello from the mvvm winui lab";
     private LanguageChoiceViewModel _selectedLanguage = null!;
+    private SerializerChoiceViewModel _selectedSerializer = null!;
     private TransportChoiceViewModel _selectedTransport = null!;
 
     public DeviceLabSettingsViewModel(
@@ -35,6 +37,12 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
             new LanguageChoiceViewModel(AppLanguageMode.Korean, _localizer)
         ];
 
+        SerializerChoices =
+        [
+            new SerializerChoiceViewModel(SerializerTypes.AutoBinary, _localizer),
+            new SerializerChoiceViewModel(SerializerTypes.RawHex, _localizer)
+        ];
+
         TransportChoices =
         [
             new TransportChoiceViewModel(TransportKind.Tcp, _localizer),
@@ -44,11 +52,14 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
         ];
 
         _selectedLanguage = LanguageChoices[0];
+        _selectedSerializer = SerializerChoices[0];
         _selectedTransport = TransportChoices[0];
         _localizer.LanguageChanged += OnLanguageChanged;
     }
 
     public IReadOnlyList<LanguageChoiceViewModel> LanguageChoices { get; }
+
+    public IReadOnlyList<SerializerChoiceViewModel> SerializerChoices { get; }
 
     public IReadOnlyList<TransportChoiceViewModel> TransportChoices { get; }
 
@@ -110,6 +121,21 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
         }
     }
 
+    public SerializerChoiceViewModel SelectedSerializer
+    {
+        get => _selectedSerializer;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+
+            if (SetProperty(ref _selectedSerializer, value))
+            {
+                OnPropertyChanged(nameof(SelectedSerializerTitle));
+                OnPropertyChanged(nameof(SelectedSerializerSubtitle));
+            }
+        }
+    }
+
     public TransportChoiceViewModel SelectedTransport
     {
         get => _selectedTransport;
@@ -141,6 +167,10 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
 
     public string SelectedTransportSubtitle => SelectedTransport.Subtitle;
 
+    public string SelectedSerializerTitle => SelectedSerializer.Label;
+
+    public string SelectedSerializerSubtitle => SelectedSerializer.Subtitle;
+
     public DeviceLabAppSettings CreateSnapshot()
     {
         return new DeviceLabAppSettings
@@ -159,6 +189,7 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
             },
             MessageComposer = new MessageComposerAppSettings
             {
+                SerializerType = SelectedSerializer.Type,
                 OutboundMessageId = OutboundMessageId,
                 OutboundBody = OutboundBody
             },
@@ -208,6 +239,7 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
         DisplayName = settings.Session.DisplayName;
         DefaultTimeoutMs = settings.Session.DefaultTimeoutMs;
         MaxPendingRequests = settings.Session.MaxPendingRequests;
+        SelectedSerializer = ResolveSerializerChoice(settings.MessageComposer.SerializerType);
         OutboundMessageId = settings.MessageComposer.OutboundMessageId;
         OutboundBody = settings.MessageComposer.OutboundBody;
 
@@ -250,6 +282,11 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
         return TransportChoices.FirstOrDefault(choice => choice.Kind == kind) ?? TransportChoices[0];
     }
 
+    private SerializerChoiceViewModel ResolveSerializerChoice(string type)
+    {
+        return SerializerChoices.FirstOrDefault(choice => choice.Type == type) ?? SerializerChoices[0];
+    }
+
     private LanguageChoiceViewModel ResolveLanguageChoice(AppLanguageMode mode)
     {
         return LanguageChoices.FirstOrDefault(choice => choice.Mode == mode) ?? LanguageChoices[0];
@@ -257,6 +294,8 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
 
     private void OnLanguageChanged(object? sender, EventArgs args)
     {
+        OnPropertyChanged(nameof(SelectedSerializerTitle));
+        OnPropertyChanged(nameof(SelectedSerializerSubtitle));
         OnPropertyChanged(nameof(SelectedTransportTitle));
         OnPropertyChanged(nameof(SelectedTransportSubtitle));
     }

--- a/examples/CommLib.Examples.WinUI/ViewModels/DeviceLabSettingsViewModel.cs
+++ b/examples/CommLib.Examples.WinUI/ViewModels/DeviceLabSettingsViewModel.cs
@@ -1,4 +1,5 @@
 using CommLib.Domain.Configuration;
+using CommLib.Domain.Messaging;
 using CommLib.Examples.WinUI.Models;
 using CommLib.Examples.WinUI.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -14,6 +15,7 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
     private string _maxPendingRequests = "8";
     private string _outboundMessageId = "100";
     private string _outboundBody = "hello from the mvvm winui lab";
+    private BitFieldPayloadSchema? _bitFieldSchema;
     private LanguageChoiceViewModel _selectedLanguage = null!;
     private SerializerChoiceViewModel _selectedSerializer = null!;
     private TransportChoiceViewModel _selectedTransport = null!;
@@ -107,6 +109,12 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
         set => SetProperty(ref _outboundBody, value);
     }
 
+    public BitFieldPayloadSchema? BitFieldSchema
+    {
+        get => _bitFieldSchema;
+        set => SetProperty(ref _bitFieldSchema, value);
+    }
+
     public LanguageChoiceViewModel SelectedLanguage
     {
         get => _selectedLanguage;
@@ -190,6 +198,7 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
             MessageComposer = new MessageComposerAppSettings
             {
                 SerializerType = SelectedSerializer.Type,
+                BitFieldSchema = BitFieldSchema,
                 OutboundMessageId = OutboundMessageId,
                 OutboundBody = OutboundBody
             },
@@ -240,6 +249,7 @@ public sealed class DeviceLabSettingsViewModel : ObservableObject
         DefaultTimeoutMs = settings.Session.DefaultTimeoutMs;
         MaxPendingRequests = settings.Session.MaxPendingRequests;
         SelectedSerializer = ResolveSerializerChoice(settings.MessageComposer.SerializerType);
+        BitFieldSchema = settings.MessageComposer.BitFieldSchema;
         OutboundMessageId = settings.MessageComposer.OutboundMessageId;
         OutboundBody = settings.MessageComposer.OutboundBody;
 

--- a/examples/CommLib.Examples.WinUI/ViewModels/MainViewModel.cs
+++ b/examples/CommLib.Examples.WinUI/ViewModels/MainViewModel.cs
@@ -1,6 +1,8 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using CommLib.Application.Messaging;
 using CommLib.Domain.Configuration;
+using CommLib.Domain.Messaging;
 using CommLib.Examples.WinUI.Models;
 using CommLib.Examples.WinUI.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -41,6 +43,7 @@ public sealed class MainViewModel : ObservableObject, IAsyncDisposable
     private object[] _mockEndpointStatusDetailArgs = [];
     private bool _usesRawMockEndpointDetail;
     private string _rawMockEndpointDetail = string.Empty;
+    private string? _activeSerializerType;
     private LocalMockEndpointBinding? _activeMockEndpoint;
 
     public MainViewModel(
@@ -169,7 +172,9 @@ public sealed class MainViewModel : ObservableObject, IAsyncDisposable
 
     public string ProtocolBadgeText => "LengthPrefixed";
 
-    public string SerializerBadgeText => "AutoBinary";
+    public string SerializerBadgeText => _activeSerializerType is null
+        ? Settings.SelectedSerializerTitle
+        : _localizer.GetSerializerLabel(_activeSerializerType);
 
     public string RuntimePolicyText => "Strict MVVM + DI + JSON";
 
@@ -222,7 +227,9 @@ public sealed class MainViewModel : ObservableObject, IAsyncDisposable
         try
         {
             var profile = BuildProfile();
-            await _sessionService.ConnectAsync(profile).ConfigureAwait(false);
+            await _sessionService.ConnectAsync(profile);
+            _activeSerializerType = profile.Serializer.Type;
+            OnPropertyChanged(nameof(SerializerBadgeText));
         }
         catch (Exception exception)
         {
@@ -246,7 +253,9 @@ public sealed class MainViewModel : ObservableObject, IAsyncDisposable
 
         try
         {
-            await _sessionService.DisconnectAsync().ConfigureAwait(false);
+            await _sessionService.DisconnectAsync();
+            _activeSerializerType = null;
+            OnPropertyChanged(nameof(SerializerBadgeText));
         }
         catch (Exception exception)
         {
@@ -270,7 +279,7 @@ public sealed class MainViewModel : ObservableObject, IAsyncDisposable
 
         try
         {
-            await _sessionService.SendAsync(ParseMessageId(), Settings.OutboundBody).ConfigureAwait(false);
+            await _sessionService.SendAsync(BuildOutboundMessage());
             ApplyViewStatus("main.status.connected", "main.detail.readyNextMessage");
         }
         catch (Exception exception)
@@ -299,7 +308,7 @@ public sealed class MainViewModel : ObservableObject, IAsyncDisposable
             // mock peer는 현재 UI 설정을 그대로 읽되,
             // 실제 loopback 테스트에 필요한 최소 보정은 요청 생성 단계에서 함께 반영한다.
             var request = BuildMockEndpointRequest();
-            var binding = await _mockEndpointService.StartAsync(request).ConfigureAwait(false);
+            var binding = await _mockEndpointService.StartAsync(request);
             _activeMockEndpoint = binding;
             IsMockEndpointRunning = true;
             ApplyRunningMockEndpointStatus(binding);
@@ -333,7 +342,7 @@ public sealed class MainViewModel : ObservableObject, IAsyncDisposable
 
         try
         {
-            await _mockEndpointService.StopAsync().ConfigureAwait(false);
+            await _mockEndpointService.StopAsync();
             _activeMockEndpoint = null;
             IsMockEndpointRunning = false;
             RefreshMockEndpointStatus();
@@ -395,7 +404,7 @@ public sealed class MainViewModel : ObservableObject, IAsyncDisposable
             },
             Serializer = new SerializerOptions
             {
-                Type = "AutoBinary"
+                Type = Settings.SelectedSerializer.Type
             },
             Reconnect = new ReconnectOptions
             {
@@ -447,6 +456,20 @@ public sealed class MainViewModel : ObservableObject, IAsyncDisposable
         return messageId;
     }
 
+    private IMessage BuildOutboundMessage()
+    {
+        var serializerType = _activeSerializerType ?? Settings.SelectedSerializer.Type;
+
+        try
+        {
+            return OutboundMessageComposer.Compose(serializerType, ParseMessageId(), Settings.OutboundBody);
+        }
+        catch (FormatException) when (string.Equals(serializerType, SerializerTypes.RawHex, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(_localizer.Get("composer.error.invalidRawHex"));
+        }
+    }
+
     private void NotifyCommandStateChanged()
     {
         ConnectCommand.NotifyCanExecuteChanged();
@@ -484,6 +507,12 @@ public sealed class MainViewModel : ObservableObject, IAsyncDisposable
         {
             _statusOwner = StatusOwner.Service;
             IsConnected = snapshot.IsConnected;
+            if (!snapshot.IsConnected)
+            {
+                _activeSerializerType = null;
+                OnPropertyChanged(nameof(SerializerBadgeText));
+            }
+
             StatusText = snapshot.StatusText;
             StatusDetail = snapshot.StatusDetail;
         });
@@ -512,6 +541,14 @@ public sealed class MainViewModel : ObservableObject, IAsyncDisposable
 
     private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs args)
     {
+        if (args.PropertyName is nameof(DeviceLabSettingsViewModel.SelectedSerializer))
+        {
+            if (_activeSerializerType is null)
+            {
+                OnPropertyChanged(nameof(SerializerBadgeText));
+            }
+        }
+
         if (args.PropertyName is nameof(DeviceLabSettingsViewModel.SelectedTransport))
         {
             if (!IsMockEndpointRunning)

--- a/examples/CommLib.Examples.WinUI/ViewModels/SerializerChoiceViewModel.cs
+++ b/examples/CommLib.Examples.WinUI/ViewModels/SerializerChoiceViewModel.cs
@@ -1,0 +1,28 @@
+using CommLib.Examples.WinUI.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace CommLib.Examples.WinUI.ViewModels;
+
+public sealed class SerializerChoiceViewModel : ObservableObject
+{
+    private readonly IAppLocalizer _localizer;
+
+    public SerializerChoiceViewModel(string type, IAppLocalizer localizer)
+    {
+        Type = type;
+        _localizer = localizer;
+        _localizer.LanguageChanged += OnLanguageChanged;
+    }
+
+    public string Type { get; }
+
+    public string Label => _localizer.GetSerializerLabel(Type);
+
+    public string Subtitle => _localizer.GetSerializerSubtitle(Type);
+
+    private void OnLanguageChanged(object? sender, EventArgs args)
+    {
+        OnPropertyChanged(nameof(Label));
+        OnPropertyChanged(nameof(Subtitle));
+    }
+}

--- a/examples/CommLib.Examples.WinUI/ViewModels/SettingsViewModel.cs
+++ b/examples/CommLib.Examples.WinUI/ViewModels/SettingsViewModel.cs
@@ -81,7 +81,7 @@ public sealed class SettingsViewModel : ObservableObject
 
         try
         {
-            await _settingsStore.SaveAsync(Settings.CreateSnapshot()).ConfigureAwait(false);
+            await _settingsStore.SaveAsync(Settings.CreateSnapshot());
             SetLocalizedStatus(
                 "settings.status.saved.title",
                 "settings.status.saved.detail",
@@ -107,7 +107,7 @@ public sealed class SettingsViewModel : ObservableObject
 
         try
         {
-            var settings = await _settingsStore.LoadAsync().ConfigureAwait(false);
+            var settings = await _settingsStore.LoadAsync();
             Settings.Apply(settings);
             SetLocalizedStatus(
                 "settings.status.reloaded.title",

--- a/examples/CommLib.Examples.WinUI/Views/DeviceLabView.cs
+++ b/examples/CommLib.Examples.WinUI/Views/DeviceLabView.cs
@@ -195,9 +195,22 @@ public sealed class DeviceLabView : Grid
         var stack = CreateVerticalStack(12);
         stack.Children.Add(CreateSectionTitle("deviceLab.section.messageComposer"));
 
+        var serializer = CreateComboBox("Settings.SerializerChoices", "Settings.SelectedSerializer");
+        serializer.DisplayMemberPath = "Label";
+
         stack.Children.Add(CreateTwoColumnRow(
             CreateLabeledField("field.messageId", CreateTextBox("Settings.OutboundMessageId")),
-            CreateLabeledField("field.body", CreateTextBox("Settings.OutboundBody", 120, true))));
+            CreateLabeledField("field.serializer", serializer)));
+
+        var serializerHint = new TextBlock
+        {
+            Style = GetThemeStyle(DeviceLabTheme.BodyCaptionStyleKey),
+            TextWrapping = TextWrapping.WrapWholeWords
+        };
+        Bind(serializerHint, TextBlock.TextProperty, "Settings.SelectedSerializerSubtitle");
+        stack.Children.Add(serializerHint);
+
+        stack.Children.Add(CreateLabeledField("field.body", CreateTextBox("Settings.OutboundBody", 120, true)));
 
         var buttons = new StackPanel
         {

--- a/examples/CommLib.Examples.WinUI/Views/SettingsView.cs
+++ b/examples/CommLib.Examples.WinUI/Views/SettingsView.cs
@@ -162,9 +162,23 @@ public sealed class SettingsView : Grid
         var card = CreateCard();
         var stack = CreateVerticalStack(12);
         stack.Children.Add(CreateSectionTitle("settings.section.messageDefaults"));
+
+        var serializer = CreateComboBox("Settings.SerializerChoices", "Settings.SelectedSerializer");
+        serializer.DisplayMemberPath = "Label";
+
         stack.Children.Add(CreateTwoColumnRow(
             CreateLabeledField("field.messageId", CreateTextBox("Settings.OutboundMessageId")),
-            CreateLabeledField("field.body", CreateTextBox("Settings.OutboundBody", 120, true))));
+            CreateLabeledField("field.serializer", serializer)));
+
+        var serializerHint = new TextBlock
+        {
+            Style = GetThemeStyle(DeviceLabTheme.BodyCaptionStyleKey),
+            TextWrapping = TextWrapping.WrapWholeWords
+        };
+        Bind(serializerHint, TextBlock.TextProperty, "Settings.SelectedSerializerSubtitle");
+        stack.Children.Add(serializerHint);
+
+        stack.Children.Add(CreateLabeledField("field.body", CreateTextBox("Settings.OutboundBody", 120, true)));
         card.Child = stack;
         return card;
     }

--- a/examples/CommLib.Examples.WinUI/appsettings.json
+++ b/examples/CommLib.Examples.WinUI/appsettings.json
@@ -10,6 +10,7 @@
     "selectedTransport": "Tcp"
   },
   "messageComposer": {
+    "serializerType": "AutoBinary",
     "outboundMessageId": "100",
     "outboundBody": "hello from the mvvm winui lab"
   },

--- a/examples/CommLib.Examples.WinUI/appsettings.json
+++ b/examples/CommLib.Examples.WinUI/appsettings.json
@@ -11,6 +11,17 @@
   },
   "messageComposer": {
     "serializerType": "AutoBinary",
+    // Optional RawHex log-enrichment example:
+    // 1. Change serializerType to "RawHex".
+    // 2. Add a bitFieldSchema like the README example below.
+    // "bitFieldSchema": {
+    //   "payloadLengthBytes": 4,
+    //   "fields": [
+    //     { "name": "prefix", "bitOffset": 0, "bitLength": 8 },
+    //     { "name": "register", "bitOffset": 8, "bitLength": 16, "endianness": "BigEndian" },
+    //     { "name": "tail", "bitOffset": 24, "bitLength": 8 }
+    //   ]
+    // },
     "outboundMessageId": "100",
     "outboundBody": "hello from the mvvm winui lab"
   },

--- a/src/CommLib.Application/Configuration/DeviceProfileValidator.cs
+++ b/src/CommLib.Application/Configuration/DeviceProfileValidator.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using CommLib.Domain.Configuration;
+using CommLib.Domain.Messaging;
 
 namespace CommLib.Application.Configuration;
 
@@ -39,6 +40,7 @@ public static class DeviceProfileValidator
             throw new InvalidOperationException($"[{profile.DeviceId}] MaxPendingRequests must be greater than 0.");
         }
 
+        ValidateSerializerOptions(profile);
         ValidateReconnectOptions(profile);
 
         switch (profile.Transport)
@@ -159,6 +161,28 @@ public static class DeviceProfileValidator
         var bytes = address.GetAddressBytes();
         return address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork &&
                bytes[0] is >= 224 and <= 239;
+    }
+
+    private static void ValidateSerializerOptions(DeviceProfile profile)
+    {
+        if (profile.Serializer.BitFieldSchema is null)
+        {
+            return;
+        }
+
+        if (!string.Equals(profile.Serializer.Type, SerializerTypes.RawHex, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"[{profile.DeviceId}] BitFieldSchema requires the RawHex serializer.");
+        }
+
+        try
+        {
+            BitFieldPayloadSchemaValidator.ValidateAndThrow(profile.Serializer.BitFieldSchema);
+        }
+        catch (InvalidOperationException exception)
+        {
+            throw new InvalidOperationException($"[{profile.DeviceId}] Invalid BitFieldSchema: {exception.Message}", exception);
+        }
     }
 
     private static void ValidateReconnectOptions(DeviceProfile profile)

--- a/src/CommLib.Application/Messaging/OutboundMessageComposer.cs
+++ b/src/CommLib.Application/Messaging/OutboundMessageComposer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using CommLib.Domain.Configuration;
 using CommLib.Domain.Messaging;
 
@@ -23,5 +24,17 @@ public static class OutboundMessageComposer
             SerializerTypes.RawHex => new BinaryMessageModel(messageId, HexPayloadParser.Parse(body)),
             _ => throw new NotSupportedException($"Unsupported serializer: {serializerType}")
         };
+    }
+
+    /// <summary>
+    /// bitfield schema와 named field assignment를 raw binary outbound 메시지로 조합합니다.
+    /// </summary>
+    /// <param name="messageId">메시지 식별자입니다.</param>
+    /// <param name="schema">payload compose에 적용할 bitfield schema입니다.</param>
+    /// <param name="fieldValues">schema field에 쓸 값 목록입니다.</param>
+    /// <returns>compose된 raw payload를 담은 binary outbound 메시지입니다.</returns>
+    public static IMessage Compose(ushort messageId, BitFieldPayloadSchema schema, IEnumerable<BitFieldFieldAssignment> fieldValues)
+    {
+        return new BinaryMessageModel(messageId, BitFieldPayloadSchemaCodec.Compose(schema, fieldValues));
     }
 }

--- a/src/CommLib.Application/Messaging/OutboundMessageComposer.cs
+++ b/src/CommLib.Application/Messaging/OutboundMessageComposer.cs
@@ -1,0 +1,27 @@
+using CommLib.Domain.Configuration;
+using CommLib.Domain.Messaging;
+
+namespace CommLib.Application.Messaging;
+
+/// <summary>
+/// ?좏깮??serializer 紐⑤뱶??留욌뒗 outbound 硫붿떆吏 紐⑤뜽??議고빀?⑸땲??
+/// </summary>
+public static class OutboundMessageComposer
+{
+    /// <summary>
+    /// serializer ?좏삎???곕씪 text ?먮뒗 binary outbound 硫붿떆吏瑜??앹꽦?⑸땲??
+    /// </summary>
+    /// <param name="serializerType">?쒖꽦 serializer ?앸퀎?먯엯?덈떎.</param>
+    /// <param name="messageId">硫붿떆吏 ?앸퀎?먯엯?덈떎.</param>
+    /// <param name="body">?ъ슜???낅젰 蹂몃Ц?낅땲??</param>
+    /// <returns>?꾩넚??硫붿떆吏 紐⑤뜽?낅땲??</returns>
+    public static IMessage Compose(string serializerType, ushort messageId, string body)
+    {
+        return serializerType switch
+        {
+            SerializerTypes.AutoBinary => new MessageModel(messageId, body),
+            SerializerTypes.RawHex => new BinaryMessageModel(messageId, HexPayloadParser.Parse(body)),
+            _ => throw new NotSupportedException($"Unsupported serializer: {serializerType}")
+        };
+    }
+}

--- a/src/CommLib.Domain/Configuration/SerializerOptions.cs
+++ b/src/CommLib.Domain/Configuration/SerializerOptions.cs
@@ -1,3 +1,5 @@
+using CommLib.Domain.Messaging;
+
 namespace CommLib.Domain.Configuration;
 
 /// <summary>
@@ -8,5 +10,10 @@ public sealed class SerializerOptions
     /// <summary>
     /// 직렬화기 구현 이름을 가져옵니다.
     /// </summary>
-    public string Type { get; init; } = "AutoBinary";
+    public string Type { get; init; } = SerializerTypes.AutoBinary;
+
+    /// <summary>
+    /// raw payload bitfield schema 설정이 필요할 때 사용하는 optional schema입니다.
+    /// </summary>
+    public BitFieldPayloadSchema? BitFieldSchema { get; init; }
 }

--- a/src/CommLib.Domain/Configuration/SerializerTypes.cs
+++ b/src/CommLib.Domain/Configuration/SerializerTypes.cs
@@ -1,0 +1,17 @@
+namespace CommLib.Domain.Configuration;
+
+/// <summary>
+/// 저장소와 예제 앱 전반에서 공용으로 사용하는 serializer 식별자 모음입니다.
+/// </summary>
+public static class SerializerTypes
+{
+    /// <summary>
+    /// 텍스트 본문을 기존 예제 serializer 형식으로 처리합니다.
+    /// </summary>
+    public const string AutoBinary = "AutoBinary";
+
+    /// <summary>
+    /// payload를 raw hexadecimal 바이트로 해석합니다.
+    /// </summary>
+    public const string RawHex = "RawHex";
+}

--- a/src/CommLib.Domain/Messaging/BitFieldCodec.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldCodec.cs
@@ -1,0 +1,114 @@
+namespace CommLib.Domain.Messaging;
+
+/// <summary>
+/// raw payload를 bitfield 단위로 읽고 쓰는 공용 codec입니다.
+/// </summary>
+public static class BitFieldCodec
+{
+    /// <summary>
+    /// 지정한 bitfield를 unsigned 정수로 읽습니다.
+    /// </summary>
+    /// <param name="payload">원본 payload입니다.</param>
+    /// <param name="field">읽을 field 정의입니다.</param>
+    /// <returns>field 구간의 unsigned 값입니다.</returns>
+    public static ulong ReadUnsigned(ReadOnlySpan<byte> payload, BitFieldDefinition field)
+    {
+        ArgumentNullException.ThrowIfNull(field);
+        EnsureFieldFits(payload.Length, field);
+
+        ulong value = 0;
+        for (var bitIndex = 0; bitIndex < field.BitLength; bitIndex++)
+        {
+            var absoluteBitIndex = field.BitOffset + bitIndex;
+            var byteIndex = absoluteBitIndex / 8;
+            var bitInByte = absoluteBitIndex % 8;
+            var bit = (payload[byteIndex] >> bitInByte) & 0x01;
+            value |= (ulong)bit << bitIndex;
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// 지정한 bitfield를 signed 정수로 읽습니다.
+    /// </summary>
+    /// <param name="payload">원본 payload입니다.</param>
+    /// <param name="field">읽을 field 정의입니다.</param>
+    /// <returns>field 구간의 signed 값입니다.</returns>
+    public static long ReadSigned(ReadOnlySpan<byte> payload, BitFieldDefinition field)
+    {
+        var value = ReadUnsigned(payload, field);
+        if (field.BitLength == 64)
+        {
+            return unchecked((long)value);
+        }
+
+        var signBitMask = 1UL << (field.BitLength - 1);
+        if ((value & signBitMask) == 0)
+        {
+            return (long)value;
+        }
+
+        var extensionMask = ulong.MaxValue << field.BitLength;
+        return unchecked((long)(value | extensionMask));
+    }
+
+    /// <summary>
+    /// 지정한 bitfield 구간에 unsigned 정수 값을 씁니다.
+    /// </summary>
+    /// <param name="payload">쓰기 대상 payload입니다.</param>
+    /// <param name="field">쓸 field 정의입니다.</param>
+    /// <param name="value">쓸 unsigned 값입니다.</param>
+    public static void WriteUnsigned(Span<byte> payload, BitFieldDefinition field, ulong value)
+    {
+        ArgumentNullException.ThrowIfNull(field);
+        EnsureFieldFits(payload.Length, field);
+        EnsureValueFits(field, value);
+
+        for (var bitIndex = 0; bitIndex < field.BitLength; bitIndex++)
+        {
+            var absoluteBitIndex = field.BitOffset + bitIndex;
+            var byteIndex = absoluteBitIndex / 8;
+            var bitInByte = absoluteBitIndex % 8;
+            var mask = (byte)(1 << bitInByte);
+            var bit = (value >> bitIndex) & 0x01;
+
+            if (bit == 1)
+            {
+                payload[byteIndex] |= mask;
+            }
+            else
+            {
+                payload[byteIndex] &= unchecked((byte)~mask);
+            }
+        }
+    }
+
+    private static void EnsureFieldFits(int payloadLength, BitFieldDefinition field)
+    {
+        var payloadBitLength = checked(payloadLength * 8);
+        var fieldEnd = checked(field.BitOffset + field.BitLength);
+        if (fieldEnd > payloadBitLength)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(field),
+                $"Bit field '{field.Name}' exceeds payload length {payloadLength} byte(s).");
+        }
+    }
+
+    private static void EnsureValueFits(BitFieldDefinition field, ulong value)
+    {
+        if (field.BitLength == 64)
+        {
+            return;
+        }
+
+        var maxValue = (1UL << field.BitLength) - 1;
+        if (value > maxValue)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                $"Value {value} does not fit in bit field '{field.Name}' ({field.BitLength} bit(s)).");
+        }
+    }
+}

--- a/src/CommLib.Domain/Messaging/BitFieldCodec.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldCodec.cs
@@ -1,40 +1,35 @@
 namespace CommLib.Domain.Messaging;
 
 /// <summary>
-/// raw payload를 bitfield 단위로 읽고 쓰는 공용 codec입니다.
+/// Reads and writes scalar values against bitfield definitions in a raw payload.
 /// </summary>
 public static class BitFieldCodec
 {
     /// <summary>
-    /// 지정한 bitfield를 unsigned 정수로 읽습니다.
+    /// Reads a bitfield as an unsigned integer.
     /// </summary>
-    /// <param name="payload">원본 payload입니다.</param>
-    /// <param name="field">읽을 field 정의입니다.</param>
-    /// <returns>field 구간의 unsigned 값입니다.</returns>
+    /// <param name="payload">The source payload.</param>
+    /// <param name="field">The field to read.</param>
+    /// <returns>The unsigned value stored in the field.</returns>
     public static ulong ReadUnsigned(ReadOnlySpan<byte> payload, BitFieldDefinition field)
     {
         ArgumentNullException.ThrowIfNull(field);
         EnsureFieldFits(payload.Length, field);
 
-        ulong value = 0;
-        for (var bitIndex = 0; bitIndex < field.BitLength; bitIndex++)
+        return field.Endianness switch
         {
-            var absoluteBitIndex = field.BitOffset + bitIndex;
-            var byteIndex = absoluteBitIndex / 8;
-            var bitInByte = absoluteBitIndex % 8;
-            var bit = (payload[byteIndex] >> bitInByte) & 0x01;
-            value |= (ulong)bit << bitIndex;
-        }
-
-        return value;
+            BitFieldEndianness.LittleEndian => ReadUnsignedLittleEndian(payload, field),
+            BitFieldEndianness.BigEndian => ReadUnsignedBigEndian(payload, field),
+            _ => throw new ArgumentOutOfRangeException(nameof(field), $"Bit field '{field.Name}' has an unsupported endianness.")
+        };
     }
 
     /// <summary>
-    /// 지정한 bitfield를 signed 정수로 읽습니다.
+    /// Reads a bitfield as a signed integer.
     /// </summary>
-    /// <param name="payload">원본 payload입니다.</param>
-    /// <param name="field">읽을 field 정의입니다.</param>
-    /// <returns>field 구간의 signed 값입니다.</returns>
+    /// <param name="payload">The source payload.</param>
+    /// <param name="field">The field to read.</param>
+    /// <returns>The signed value stored in the field.</returns>
     public static long ReadSigned(ReadOnlySpan<byte> payload, BitFieldDefinition field)
     {
         var value = ReadUnsigned(payload, field);
@@ -54,17 +49,68 @@ public static class BitFieldCodec
     }
 
     /// <summary>
-    /// 지정한 bitfield 구간에 unsigned 정수 값을 씁니다.
+    /// Writes an unsigned integer value into a bitfield.
     /// </summary>
-    /// <param name="payload">쓰기 대상 payload입니다.</param>
-    /// <param name="field">쓸 field 정의입니다.</param>
-    /// <param name="value">쓸 unsigned 값입니다.</param>
+    /// <param name="payload">The destination payload.</param>
+    /// <param name="field">The field to write.</param>
+    /// <param name="value">The unsigned value to write.</param>
     public static void WriteUnsigned(Span<byte> payload, BitFieldDefinition field, ulong value)
     {
         ArgumentNullException.ThrowIfNull(field);
         EnsureFieldFits(payload.Length, field);
         EnsureValueFits(field, value);
 
+        switch (field.Endianness)
+        {
+            case BitFieldEndianness.LittleEndian:
+                WriteUnsignedLittleEndian(payload, field, value);
+                return;
+
+            case BitFieldEndianness.BigEndian:
+                WriteUnsignedBigEndian(payload, field, value);
+                return;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(field), $"Bit field '{field.Name}' has an unsupported endianness.");
+        }
+    }
+
+    private static ulong ReadUnsignedLittleEndian(ReadOnlySpan<byte> payload, BitFieldDefinition field)
+    {
+        ulong value = 0;
+        for (var bitIndex = 0; bitIndex < field.BitLength; bitIndex++)
+        {
+            var absoluteBitIndex = field.BitOffset + bitIndex;
+            var byteIndex = absoluteBitIndex / 8;
+            var bitInByte = absoluteBitIndex % 8;
+            var bit = (payload[byteIndex] >> bitInByte) & 0x01;
+            value |= (ulong)bit << bitIndex;
+        }
+
+        return value;
+    }
+
+    private static ulong ReadUnsignedBigEndian(ReadOnlySpan<byte> payload, BitFieldDefinition field)
+    {
+        if (field.BitLength <= 8)
+        {
+            return ReadUnsignedLittleEndian(payload, field);
+        }
+
+        var byteIndex = field.BitOffset / 8;
+        var byteCount = field.BitLength / 8;
+        ulong value = 0;
+
+        for (var index = 0; index < byteCount; index++)
+        {
+            value = (value << 8) | payload[byteIndex + index];
+        }
+
+        return value;
+    }
+
+    private static void WriteUnsignedLittleEndian(Span<byte> payload, BitFieldDefinition field, ulong value)
+    {
         for (var bitIndex = 0; bitIndex < field.BitLength; bitIndex++)
         {
             var absoluteBitIndex = field.BitOffset + bitIndex;
@@ -81,6 +127,24 @@ public static class BitFieldCodec
             {
                 payload[byteIndex] &= unchecked((byte)~mask);
             }
+        }
+    }
+
+    private static void WriteUnsignedBigEndian(Span<byte> payload, BitFieldDefinition field, ulong value)
+    {
+        if (field.BitLength <= 8)
+        {
+            WriteUnsignedLittleEndian(payload, field, value);
+            return;
+        }
+
+        var byteIndex = field.BitOffset / 8;
+        var byteCount = field.BitLength / 8;
+
+        for (var index = 0; index < byteCount; index++)
+        {
+            var shift = (byteCount - index - 1) * 8;
+            payload[byteIndex + index] = (byte)((value >> shift) & 0xFF);
         }
     }
 

--- a/src/CommLib.Domain/Messaging/BitFieldDefinition.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldDefinition.cs
@@ -1,17 +1,22 @@
 namespace CommLib.Domain.Messaging;
 
 /// <summary>
-/// raw payload 안의 bitfield 한 구간을 설명하는 정의입니다.
+/// Describes a named bitfield range inside a raw payload.
 /// </summary>
 public sealed record BitFieldDefinition
 {
     /// <summary>
-    /// <see cref="BitFieldDefinition"/> 인스턴스를 초기화합니다.
+    /// Initializes a <see cref="BitFieldDefinition"/> instance.
     /// </summary>
-    /// <param name="name">필드 이름입니다.</param>
-    /// <param name="bitOffset">payload 시작점 기준 bit offset입니다. bit 0은 첫 번째 byte의 LSB입니다.</param>
-    /// <param name="bitLength">필드 bit 길이입니다. 현재 최대 64 bit까지 지원합니다.</param>
-    public BitFieldDefinition(string name, int bitOffset, int bitLength)
+    /// <param name="name">The field name.</param>
+    /// <param name="bitOffset">The field offset from the start of the payload. Bit 0 is the LSB of the first byte.</param>
+    /// <param name="bitLength">The field length in bits. The current implementation supports up to 64 bits.</param>
+    /// <param name="endianness">The byte order used when a field spans multiple whole bytes.</param>
+    public BitFieldDefinition(
+        string name,
+        int bitOffset,
+        int bitLength,
+        BitFieldEndianness endianness = BitFieldEndianness.LittleEndian)
     {
         if (string.IsNullOrWhiteSpace(name))
         {
@@ -28,23 +33,43 @@ public sealed record BitFieldDefinition
             throw new ArgumentOutOfRangeException(nameof(bitLength), "Bit field length must be between 1 and 64 bits.");
         }
 
+        if (!Enum.IsDefined(endianness))
+        {
+            throw new ArgumentOutOfRangeException(nameof(endianness), "Bit field endianness is invalid.");
+        }
+
+        if (endianness == BitFieldEndianness.BigEndian &&
+            bitLength > 8 &&
+            (bitOffset % 8 != 0 || bitLength % 8 != 0))
+        {
+            throw new ArgumentException(
+                "Big-endian bit fields wider than one byte must be byte-aligned and use a whole-byte length.",
+                nameof(bitLength));
+        }
+
         Name = name;
         BitOffset = bitOffset;
         BitLength = bitLength;
+        Endianness = endianness;
     }
 
     /// <summary>
-    /// 필드 이름입니다.
+    /// Gets the field name.
     /// </summary>
     public string Name { get; }
 
     /// <summary>
-    /// payload 시작점 기준 bit offset입니다. bit 0은 첫 번째 byte의 LSB입니다.
+    /// Gets the field offset from the start of the payload. Bit 0 is the LSB of the first byte.
     /// </summary>
     public int BitOffset { get; }
 
     /// <summary>
-    /// 필드 bit 길이입니다.
+    /// Gets the field length in bits.
     /// </summary>
     public int BitLength { get; }
+
+    /// <summary>
+    /// Gets the byte order used when a field spans multiple whole bytes.
+    /// </summary>
+    public BitFieldEndianness Endianness { get; }
 }

--- a/src/CommLib.Domain/Messaging/BitFieldDefinition.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldDefinition.cs
@@ -1,0 +1,50 @@
+namespace CommLib.Domain.Messaging;
+
+/// <summary>
+/// raw payload 안의 bitfield 한 구간을 설명하는 정의입니다.
+/// </summary>
+public sealed record BitFieldDefinition
+{
+    /// <summary>
+    /// <see cref="BitFieldDefinition"/> 인스턴스를 초기화합니다.
+    /// </summary>
+    /// <param name="name">필드 이름입니다.</param>
+    /// <param name="bitOffset">payload 시작점 기준 bit offset입니다. bit 0은 첫 번째 byte의 LSB입니다.</param>
+    /// <param name="bitLength">필드 bit 길이입니다. 현재 최대 64 bit까지 지원합니다.</param>
+    public BitFieldDefinition(string name, int bitOffset, int bitLength)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Bit field name is required.", nameof(name));
+        }
+
+        if (bitOffset < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bitOffset), "Bit field offset must be greater than or equal to 0.");
+        }
+
+        if (bitLength is <= 0 or > 64)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bitLength), "Bit field length must be between 1 and 64 bits.");
+        }
+
+        Name = name;
+        BitOffset = bitOffset;
+        BitLength = bitLength;
+    }
+
+    /// <summary>
+    /// 필드 이름입니다.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// payload 시작점 기준 bit offset입니다. bit 0은 첫 번째 byte의 LSB입니다.
+    /// </summary>
+    public int BitOffset { get; }
+
+    /// <summary>
+    /// 필드 bit 길이입니다.
+    /// </summary>
+    public int BitLength { get; }
+}

--- a/src/CommLib.Domain/Messaging/BitFieldEndianness.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldEndianness.cs
@@ -1,0 +1,17 @@
+namespace CommLib.Domain.Messaging;
+
+/// <summary>
+/// Controls the byte order used for multi-byte bitfield values.
+/// </summary>
+public enum BitFieldEndianness
+{
+    /// <summary>
+    /// The lowest-addressed byte is the least-significant byte.
+    /// </summary>
+    LittleEndian = 0,
+
+    /// <summary>
+    /// The lowest-addressed byte is the most-significant byte.
+    /// </summary>
+    BigEndian = 1
+}

--- a/src/CommLib.Domain/Messaging/BitFieldFieldAssignment.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldFieldAssignment.cs
@@ -1,0 +1,33 @@
+namespace CommLib.Domain.Messaging;
+
+/// <summary>
+/// schema-backed payload compose 시점의 field 값 한 건을 표현합니다.
+/// </summary>
+public sealed record BitFieldFieldAssignment
+{
+    /// <summary>
+    /// <see cref="BitFieldFieldAssignment"/> 인스턴스를 초기화합니다.
+    /// </summary>
+    /// <param name="name">값을 할당할 field 이름입니다.</param>
+    /// <param name="value">적용할 integer 값입니다.</param>
+    public BitFieldFieldAssignment(string name, decimal value)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Bit field assignment name is required.", nameof(name));
+        }
+
+        Name = name;
+        Value = value;
+    }
+
+    /// <summary>
+    /// 값을 할당할 field 이름입니다.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// compose 시점에 field에 쓸 integer 값입니다.
+    /// </summary>
+    public decimal Value { get; }
+}

--- a/src/CommLib.Domain/Messaging/BitFieldFieldValue.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldFieldValue.cs
@@ -1,0 +1,37 @@
+namespace CommLib.Domain.Messaging;
+
+/// <summary>
+/// schema 기반 inspect 결과로 읽어낸 field 값 한 건입니다.
+/// </summary>
+public sealed record BitFieldFieldValue
+{
+    /// <summary>
+    /// <see cref="BitFieldFieldValue"/> 인스턴스를 초기화합니다.
+    /// </summary>
+    /// <param name="field">값을 읽어낸 field 정의입니다.</param>
+    /// <param name="scalarKind">field 값을 어떤 방식으로 해석했는지 나타냅니다.</param>
+    /// <param name="value">해석된 integer 값입니다.</param>
+    public BitFieldFieldValue(BitFieldDefinition field, BitFieldScalarKind scalarKind, decimal value)
+    {
+        ArgumentNullException.ThrowIfNull(field);
+
+        Field = field;
+        ScalarKind = scalarKind;
+        Value = value;
+    }
+
+    /// <summary>
+    /// inspect 결과의 대상 field 정의입니다.
+    /// </summary>
+    public BitFieldDefinition Field { get; }
+
+    /// <summary>
+    /// 값을 unsigned/signed 중 어떤 방식으로 해석했는지 나타냅니다.
+    /// </summary>
+    public BitFieldScalarKind ScalarKind { get; }
+
+    /// <summary>
+    /// field에서 읽어낸 integer 값입니다.
+    /// </summary>
+    public decimal Value { get; }
+}

--- a/src/CommLib.Domain/Messaging/BitFieldPayloadField.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldPayloadField.cs
@@ -1,0 +1,33 @@
+namespace CommLib.Domain.Messaging;
+
+/// <summary>
+/// payload schema 안의 하나의 named bitfield를 정의합니다.
+/// </summary>
+public sealed class BitFieldPayloadField
+{
+    /// <summary>
+    /// 필드 이름입니다.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// payload 시작 기준 bit offset입니다. bit 0은 첫 번째 byte의 LSB입니다.
+    /// </summary>
+    public int BitOffset { get; init; }
+
+    /// <summary>
+    /// 필드 bit 길이입니다.
+    /// </summary>
+    public int BitLength { get; init; }
+
+    /// <summary>
+    /// 이 필드를 unsigned/signed 중 어떤 방식으로 읽고 쓸지 지정합니다.
+    /// </summary>
+    public BitFieldScalarKind ScalarKind { get; init; } = BitFieldScalarKind.Unsigned;
+
+    /// <summary>
+    /// low-level bit codec가 사용하는 <see cref="BitFieldDefinition"/>으로 변환합니다.
+    /// </summary>
+    /// <returns>검증 가능한 <see cref="BitFieldDefinition"/> 인스턴스입니다.</returns>
+    public BitFieldDefinition ToDefinition() => new(Name, BitOffset, BitLength);
+}

--- a/src/CommLib.Domain/Messaging/BitFieldPayloadField.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldPayloadField.cs
@@ -1,33 +1,38 @@
 namespace CommLib.Domain.Messaging;
 
 /// <summary>
-/// payload schema 안의 하나의 named bitfield를 정의합니다.
+/// Defines one named bitfield inside a payload schema.
 /// </summary>
 public sealed class BitFieldPayloadField
 {
     /// <summary>
-    /// 필드 이름입니다.
+    /// Gets or initializes the field name.
     /// </summary>
     public required string Name { get; init; }
 
     /// <summary>
-    /// payload 시작 기준 bit offset입니다. bit 0은 첫 번째 byte의 LSB입니다.
+    /// Gets or initializes the field offset from the start of the payload. Bit 0 is the LSB of the first byte.
     /// </summary>
     public int BitOffset { get; init; }
 
     /// <summary>
-    /// 필드 bit 길이입니다.
+    /// Gets or initializes the field length in bits.
     /// </summary>
     public int BitLength { get; init; }
 
     /// <summary>
-    /// 이 필드를 unsigned/signed 중 어떤 방식으로 읽고 쓸지 지정합니다.
+    /// Gets or initializes whether the value should be interpreted as unsigned or signed.
     /// </summary>
     public BitFieldScalarKind ScalarKind { get; init; } = BitFieldScalarKind.Unsigned;
 
     /// <summary>
-    /// low-level bit codec가 사용하는 <see cref="BitFieldDefinition"/>으로 변환합니다.
+    /// Gets or initializes the byte order used when a field spans multiple whole bytes.
     /// </summary>
-    /// <returns>검증 가능한 <see cref="BitFieldDefinition"/> 인스턴스입니다.</returns>
-    public BitFieldDefinition ToDefinition() => new(Name, BitOffset, BitLength);
+    public BitFieldEndianness Endianness { get; init; } = BitFieldEndianness.LittleEndian;
+
+    /// <summary>
+    /// Converts the schema field to the low-level codec definition.
+    /// </summary>
+    /// <returns>A validated <see cref="BitFieldDefinition"/> instance.</returns>
+    public BitFieldDefinition ToDefinition() => new(Name, BitOffset, BitLength, Endianness);
 }

--- a/src/CommLib.Domain/Messaging/BitFieldPayloadSchema.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldPayloadSchema.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace CommLib.Domain.Messaging;
+
+/// <summary>
+/// raw payload의 고정 길이와 named bitfield 목록을 함께 정의하는 schema입니다.
+/// </summary>
+public sealed class BitFieldPayloadSchema
+{
+    /// <summary>
+    /// schema가 적용되는 payload 총 byte 길이입니다.
+    /// </summary>
+    public int PayloadLengthBytes { get; init; }
+
+    /// <summary>
+    /// payload에 배치된 bitfield 목록입니다.
+    /// </summary>
+    public IReadOnlyList<BitFieldPayloadField> Fields { get; init; } = Array.Empty<BitFieldPayloadField>();
+}

--- a/src/CommLib.Domain/Messaging/BitFieldPayloadSchemaCodec.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldPayloadSchemaCodec.cs
@@ -1,0 +1,180 @@
+using System.Collections.Generic;
+
+namespace CommLib.Domain.Messaging;
+
+/// <summary>
+/// named field 값을 schema-backed raw payload로 compose하고, raw payload를 named field 값으로 inspect합니다.
+/// </summary>
+public static class BitFieldPayloadSchemaCodec
+{
+    /// <summary>
+    /// named field 값을 schema에서 정의한 payload byte 배열로 compose합니다. 값이 없는 field는 0으로 남겨둡니다.
+    /// </summary>
+    /// <param name="schema">compose에 적용할 payload schema입니다.</param>
+    /// <param name="fieldValues">schema field 이름 기반 assignment 목록입니다.</param>
+    /// <returns>schema 길이에 맞는 raw payload byte 배열입니다.</returns>
+    public static byte[] Compose(BitFieldPayloadSchema schema, IEnumerable<BitFieldFieldAssignment> fieldValues)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+        ArgumentNullException.ThrowIfNull(fieldValues);
+
+        BitFieldPayloadSchemaValidator.ValidateAndThrow(schema);
+
+        var payload = new byte[schema.PayloadLengthBytes];
+        var fieldsByName = BuildFieldMap(schema);
+        var assignedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var assignment in fieldValues)
+        {
+            if (assignment is null)
+            {
+                throw new InvalidOperationException("Bit field assignments cannot contain null entries.");
+            }
+
+            if (!assignedNames.Add(assignment.Name))
+            {
+                throw new InvalidOperationException($"Bit field '{assignment.Name}' was assigned more than once.");
+            }
+
+            if (!fieldsByName.TryGetValue(assignment.Name, out var field))
+            {
+                throw new InvalidOperationException($"Bit field '{assignment.Name}' is not defined in the schema.");
+            }
+
+            var rawValue = NormalizeValue(field, assignment.Value);
+            BitFieldCodec.WriteUnsigned(payload, field.ToDefinition(), rawValue);
+        }
+
+        return payload;
+    }
+
+    /// <summary>
+    /// raw payload를 schema 기반 field 값 목록으로 inspect합니다.
+    /// </summary>
+    /// <param name="schema">payload를 해석할 payload schema입니다.</param>
+    /// <param name="payload">inspect할 raw payload byte들입니다.</param>
+    /// <returns>schema field 순서대로 정렬된 inspect 결과 목록입니다.</returns>
+    public static IReadOnlyList<BitFieldFieldValue> Inspect(BitFieldPayloadSchema schema, ReadOnlySpan<byte> payload)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+
+        BitFieldPayloadSchemaValidator.ValidateAndThrow(schema);
+
+        if (payload.Length != schema.PayloadLengthBytes)
+        {
+            throw new InvalidOperationException(
+                $"Payload length {payload.Length} byte(s) does not match schema length {schema.PayloadLengthBytes} byte(s).");
+        }
+
+        var values = new List<BitFieldFieldValue>(schema.Fields.Count);
+        foreach (var field in schema.Fields)
+        {
+            var definition = field.ToDefinition();
+            decimal value = field.ScalarKind switch
+            {
+                BitFieldScalarKind.Unsigned => BitFieldCodec.ReadUnsigned(payload, definition),
+                BitFieldScalarKind.Signed => BitFieldCodec.ReadSigned(payload, definition),
+                _ => throw new InvalidOperationException($"Bit field '{definition.Name}' has an unsupported scalar kind.")
+            };
+
+            values.Add(new BitFieldFieldValue(definition, field.ScalarKind, value));
+        }
+
+        return values;
+    }
+
+    private static Dictionary<string, BitFieldPayloadField> BuildFieldMap(BitFieldPayloadSchema schema)
+    {
+        var fieldsByName = new Dictionary<string, BitFieldPayloadField>(StringComparer.OrdinalIgnoreCase);
+        foreach (var field in schema.Fields)
+        {
+            fieldsByName.Add(field.Name, field);
+        }
+
+        return fieldsByName;
+    }
+
+    private static ulong NormalizeValue(BitFieldPayloadField field, decimal value)
+    {
+        EnsureIntegralValue(field, value);
+
+        var definition = field.ToDefinition();
+        return field.ScalarKind switch
+        {
+            BitFieldScalarKind.Unsigned => NormalizeUnsignedValue(definition, value),
+            BitFieldScalarKind.Signed => NormalizeSignedValue(definition, value),
+            _ => throw new InvalidOperationException($"Bit field '{definition.Name}' has an unsupported scalar kind.")
+        };
+    }
+
+    private static void EnsureIntegralValue(BitFieldPayloadField field, decimal value)
+    {
+        if (decimal.Truncate(value) != value)
+        {
+            throw new InvalidOperationException($"Bit field '{field.Name}' requires an integer value.");
+        }
+    }
+
+    private static ulong NormalizeUnsignedValue(BitFieldDefinition field, decimal value)
+    {
+        if (value < 0)
+        {
+            throw new InvalidOperationException($"Bit field '{field.Name}' requires an unsigned value.");
+        }
+
+        var maxValue = GetUnsignedMaxValue(field.BitLength);
+        if (value > maxValue)
+        {
+            throw new InvalidOperationException(
+                $"Value {value} does not fit in unsigned bit field '{field.Name}' ({field.BitLength} bit(s)).");
+        }
+
+        return checked((ulong)value);
+    }
+
+    private static ulong NormalizeSignedValue(BitFieldDefinition field, decimal value)
+    {
+        var minValue = GetSignedMinValue(field.BitLength);
+        var maxValue = GetSignedMaxValue(field.BitLength);
+        if (value < minValue || value > maxValue)
+        {
+            throw new InvalidOperationException(
+                $"Value {value} does not fit in signed bit field '{field.Name}' ({field.BitLength} bit(s)).");
+        }
+
+        var signedValue = checked((long)value);
+        if (signedValue >= 0)
+        {
+            return checked((ulong)signedValue);
+        }
+
+        if (field.BitLength == 64)
+        {
+            return unchecked((ulong)signedValue);
+        }
+
+        var twoToBitLength = (decimal)(1UL << field.BitLength);
+        return checked((ulong)(twoToBitLength + value));
+    }
+
+    private static decimal GetUnsignedMaxValue(int bitLength)
+    {
+        return bitLength == 64
+            ? ulong.MaxValue
+            : (decimal)((1UL << bitLength) - 1);
+    }
+
+    private static decimal GetSignedMinValue(int bitLength)
+    {
+        return bitLength == 64
+            ? long.MinValue
+            : -(decimal)(1L << (bitLength - 1));
+    }
+
+    private static decimal GetSignedMaxValue(int bitLength)
+    {
+        return bitLength == 64
+            ? long.MaxValue
+            : (decimal)((1L << (bitLength - 1)) - 1);
+    }
+}

--- a/src/CommLib.Domain/Messaging/BitFieldPayloadSchemaValidator.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldPayloadSchemaValidator.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+
+namespace CommLib.Domain.Messaging;
+
+/// <summary>
+/// <see cref="BitFieldPayloadSchema"/>가 low-level bit codec로 안전하게 사용 가능한지 검증합니다.
+/// </summary>
+public static class BitFieldPayloadSchemaValidator
+{
+    /// <summary>
+    /// payload 길이, field 범위, 중복 이름, overlap 여부를 검증하고 조건을 만족하지 않으면 예외를 발생시킵니다.
+    /// </summary>
+    /// <param name="schema">검증할 payload schema입니다.</param>
+    public static void ValidateAndThrow(BitFieldPayloadSchema schema)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+
+        if (schema.PayloadLengthBytes <= 0)
+        {
+            throw new InvalidOperationException("Bit field schema PayloadLengthBytes must be greater than 0.");
+        }
+
+        if (schema.Fields is null)
+        {
+            throw new InvalidOperationException("Bit field schema Fields collection is required.");
+        }
+
+        var payloadBitLength = checked(schema.PayloadLengthBytes * 8);
+        var seenNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var definitions = new List<BitFieldDefinition>(schema.Fields.Count);
+
+        foreach (var field in schema.Fields)
+        {
+            if (field is null)
+            {
+                throw new InvalidOperationException("Bit field schema cannot contain null fields.");
+            }
+
+            if (!Enum.IsDefined(field.ScalarKind))
+            {
+                throw new InvalidOperationException($"Bit field '{field.Name}' has an unsupported scalar kind.");
+            }
+
+            BitFieldDefinition definition;
+            try
+            {
+                definition = field.ToDefinition();
+            }
+            catch (ArgumentException exception)
+            {
+                throw new InvalidOperationException(
+                    $"Bit field schema contains an invalid field definition: {exception.Message}",
+                    exception);
+            }
+
+            var fieldEnd = checked(definition.BitOffset + definition.BitLength);
+            if (fieldEnd > payloadBitLength)
+            {
+                throw new InvalidOperationException(
+                    $"Bit field '{definition.Name}' exceeds schema payload length {schema.PayloadLengthBytes} byte(s).");
+            }
+
+            if (!seenNames.Add(definition.Name))
+            {
+                throw new InvalidOperationException($"Bit field '{definition.Name}' is duplicated in the schema.");
+            }
+
+            definitions.Add(definition);
+        }
+
+        for (var leftIndex = 0; leftIndex < definitions.Count; leftIndex++)
+        {
+            var left = definitions[leftIndex];
+            for (var rightIndex = leftIndex + 1; rightIndex < definitions.Count; rightIndex++)
+            {
+                var right = definitions[rightIndex];
+                if (Overlaps(left, right))
+                {
+                    throw new InvalidOperationException(
+                        $"Bit fields '{left.Name}' and '{right.Name}' overlap in the schema.");
+                }
+            }
+        }
+    }
+
+    private static bool Overlaps(BitFieldDefinition left, BitFieldDefinition right)
+    {
+        var leftEnd = checked(left.BitOffset + left.BitLength);
+        var rightEnd = checked(right.BitOffset + right.BitLength);
+        return left.BitOffset < rightEnd && right.BitOffset < leftEnd;
+    }
+}

--- a/src/CommLib.Domain/Messaging/BitFieldScalarKind.cs
+++ b/src/CommLib.Domain/Messaging/BitFieldScalarKind.cs
@@ -1,0 +1,17 @@
+namespace CommLib.Domain.Messaging;
+
+/// <summary>
+/// bitfield scalar 값을 schema에서 어떤 방식으로 해석할지 지정합니다.
+/// </summary>
+public enum BitFieldScalarKind
+{
+    /// <summary>
+    /// 부호 없는 unsigned 정수로 해석합니다.
+    /// </summary>
+    Unsigned = 0,
+
+    /// <summary>
+    /// two's complement signed 정수로 해석합니다.
+    /// </summary>
+    Signed = 1
+}

--- a/src/CommLib.Domain/Messaging/HexPayloadParser.cs
+++ b/src/CommLib.Domain/Messaging/HexPayloadParser.cs
@@ -1,0 +1,44 @@
+using System.Text;
+
+namespace CommLib.Domain.Messaging;
+
+/// <summary>
+/// 공백 허용 hex 텍스트를 raw payload 바이트로 변환하는 도우미입니다.
+/// </summary>
+public static class HexPayloadParser
+{
+    /// <summary>
+    /// 공백을 무시하고 hex byte pair 텍스트를 byte 배열로 변환합니다.
+    /// </summary>
+    /// <param name="text">변환할 hex 텍스트입니다.</param>
+    /// <returns>변환된 payload 바이트 배열입니다.</returns>
+    public static byte[] Parse(string text)
+    {
+        var trimmed = RemoveWhitespace(text);
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            return [];
+        }
+
+        return Convert.FromHexString(trimmed);
+    }
+
+    private static string RemoveWhitespace(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(text.Length);
+        foreach (var character in text)
+        {
+            if (!char.IsWhiteSpace(character))
+            {
+                builder.Append(character);
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/CommLib.Domain/Messaging/IBinaryMessagePayload.cs
+++ b/src/CommLib.Domain/Messaging/IBinaryMessagePayload.cs
@@ -1,0 +1,12 @@
+namespace CommLib.Domain.Messaging;
+
+/// <summary>
+/// 메시지 payload를 raw binary 형태로 직접 전달하는 메시지 계약입니다.
+/// </summary>
+public interface IBinaryMessagePayload
+{
+    /// <summary>
+    /// 직렬화 전후로 유지할 raw payload 바이트입니다.
+    /// </summary>
+    ReadOnlyMemory<byte> Payload { get; }
+}

--- a/src/CommLib.Domain/Messaging/MessageModels.cs
+++ b/src/CommLib.Domain/Messaging/MessageModels.cs
@@ -8,12 +8,30 @@ namespace CommLib.Domain.Messaging;
 public sealed record MessageModel(ushort MessageId, string Body = "") : IMessage, IMessageBody;
 
 /// <summary>
+/// raw binary payload를 직접 담는 공용 메시지 모델입니다.
+/// </summary>
+/// <param name="MessageId">메시지 식별자입니다.</param>
+/// <param name="Payload">선택적 raw payload 바이트입니다.</param>
+public sealed record BinaryMessageModel(ushort MessageId, ReadOnlyMemory<byte> Payload = default) : IMessage, IBinaryMessagePayload;
+
+/// <summary>
 /// 상관관계 식별자와 선택적 본문을 담는 공용 요청 메시지 모델입니다.
 /// </summary>
 /// <param name="MessageId">메시지 식별자입니다.</param>
 /// <param name="CorrelationId">요청 상관관계 식별자입니다.</param>
 /// <param name="Body">선택적 메시지 본문입니다.</param>
 public sealed record RequestMessageModel(ushort MessageId, Guid CorrelationId, string Body = "") : IRequestMessage, IMessageBody;
+
+/// <summary>
+/// raw binary payload를 직접 담는 공용 요청 메시지 모델입니다.
+/// </summary>
+/// <param name="MessageId">메시지 식별자입니다.</param>
+/// <param name="CorrelationId">요청 상관관계 식별자입니다.</param>
+/// <param name="Payload">선택적 raw payload 바이트입니다.</param>
+public sealed record BinaryRequestMessageModel(
+    ushort MessageId,
+    Guid CorrelationId,
+    ReadOnlyMemory<byte> Payload = default) : IRequestMessage, IBinaryMessagePayload;
 
 /// <summary>
 /// 상관관계 식별자, 성공 여부, 선택적 본문을 담는 공용 응답 메시지 모델입니다.
@@ -27,3 +45,16 @@ public sealed record ResponseMessageModel(
     Guid CorrelationId,
     bool IsSuccess,
     string Body = "") : IResponseMessage, IMessageBody;
+
+/// <summary>
+/// raw binary payload를 직접 담는 공용 응답 메시지 모델입니다.
+/// </summary>
+/// <param name="MessageId">메시지 식별자입니다.</param>
+/// <param name="CorrelationId">응답 상관관계 식별자입니다.</param>
+/// <param name="IsSuccess">응답 성공 여부입니다.</param>
+/// <param name="Payload">선택적 raw payload 바이트입니다.</param>
+public sealed record BinaryResponseMessageModel(
+    ushort MessageId,
+    Guid CorrelationId,
+    bool IsSuccess,
+    ReadOnlyMemory<byte> Payload = default) : IResponseMessage, IBinaryMessagePayload;

--- a/src/CommLib.Domain/Messaging/MessagePayloadFormatter.cs
+++ b/src/CommLib.Domain/Messaging/MessagePayloadFormatter.cs
@@ -1,0 +1,57 @@
+using System.Text;
+
+namespace CommLib.Domain.Messaging;
+
+/// <summary>
+/// 메시지 본문을 사용자 표시용 문자열로 정규화하는 도우미입니다.
+/// </summary>
+public static class MessagePayloadFormatter
+{
+    /// <summary>
+    /// 텍스트 본문은 그대로 반환하고, binary payload는 공백 구분 대문자 hex로 변환합니다.
+    /// </summary>
+    /// <param name="message">표시 문자열로 바꿀 메시지입니다.</param>
+    /// <returns>사용자 표시용 본문 문자열입니다.</returns>
+    public static string FormatBody(IMessage message)
+    {
+        if (message is IMessageBody bodyMessage)
+        {
+            return bodyMessage.Body;
+        }
+
+        if (message is IBinaryMessagePayload binaryPayload)
+        {
+            return FormatHex(binaryPayload.Payload.Span);
+        }
+
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// raw binary payload를 공백 구분 대문자 hex 문자열로 변환합니다.
+    /// </summary>
+    /// <param name="payload">변환할 payload 바이트입니다.</param>
+    /// <returns>공백 구분 대문자 hex 문자열입니다.</returns>
+    public static string FormatHex(ReadOnlySpan<byte> payload)
+    {
+        if (payload.IsEmpty)
+        {
+            return string.Empty;
+        }
+
+        var hex = Convert.ToHexString(payload);
+        var builder = new StringBuilder((payload.Length * 3) - 1);
+
+        for (var index = 0; index < payload.Length; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(' ');
+            }
+
+            builder.Append(hex, index * 2, 2);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/CommLib.Domain/Messaging/MessagePayloadFormatter.cs
+++ b/src/CommLib.Domain/Messaging/MessagePayloadFormatter.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 
 namespace CommLib.Domain.Messaging;
@@ -28,6 +29,46 @@ public static class MessagePayloadFormatter
     }
 
     /// <summary>
+    /// Tries to inspect a binary payload with a bitfield schema and returns a compact field summary for logs.
+    /// </summary>
+    /// <param name="message">The message whose payload should be inspected.</param>
+    /// <param name="schema">The optional schema to apply to the payload.</param>
+    /// <param name="summary">The formatted field summary when inspection succeeds.</param>
+    /// <param name="error">The inspection error when schema inspection fails.</param>
+    /// <returns><see langword="true"/> when a schema summary was produced; otherwise <see langword="false"/>.</returns>
+    public static bool TryFormatBitFieldSummary(
+        IMessage message,
+        BitFieldPayloadSchema? schema,
+        out string? summary,
+        out string? error)
+    {
+        summary = null;
+        error = null;
+
+        if (schema is null || message is not IBinaryMessagePayload binaryPayload)
+        {
+            return false;
+        }
+
+        try
+        {
+            var values = BitFieldPayloadSchemaCodec.Inspect(schema, binaryPayload.Payload.Span);
+            if (values.Count == 0)
+            {
+                return false;
+            }
+
+            summary = FormatBitFieldValues(values);
+            return true;
+        }
+        catch (InvalidOperationException exception)
+        {
+            error = exception.Message;
+            return false;
+        }
+    }
+
+    /// <summary>
     /// raw binary payload를 공백 구분 대문자 hex 문자열로 변환합니다.
     /// </summary>
     /// <param name="payload">변환할 payload 바이트입니다.</param>
@@ -50,6 +91,26 @@ public static class MessagePayloadFormatter
             }
 
             builder.Append(hex, index * 2, 2);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string FormatBitFieldValues(IReadOnlyList<BitFieldFieldValue> values)
+    {
+        var builder = new StringBuilder();
+
+        for (var index = 0; index < values.Count; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(", ");
+            }
+
+            var value = values[index];
+            builder.Append(value.Field.Name);
+            builder.Append('=');
+            builder.Append(value.Value.ToString(CultureInfo.InvariantCulture));
         }
 
         return builder.ToString();

--- a/src/CommLib.Infrastructure/Factories/SerializerFactory.cs
+++ b/src/CommLib.Infrastructure/Factories/SerializerFactory.cs
@@ -18,7 +18,8 @@ public sealed class SerializerFactory : ISerializerFactory
     {
         return options.Type switch
         {
-            "AutoBinary" => new NoOpSerializer(),
+            SerializerTypes.AutoBinary => new NoOpSerializer(),
+            SerializerTypes.RawHex => new RawHexSerializer(),
             _ => throw new NotSupportedException($"Unsupported serializer: {options.Type}")
         };
     }

--- a/src/CommLib.Infrastructure/Protocol/RawHexSerializer.cs
+++ b/src/CommLib.Infrastructure/Protocol/RawHexSerializer.cs
@@ -1,0 +1,138 @@
+using System.Globalization;
+using System.Text;
+using CommLib.Domain.Messaging;
+using CommLib.Domain.Protocol;
+
+namespace CommLib.Infrastructure.Protocol;
+
+/// <summary>
+/// 메시지 메타데이터 헤더 뒤에 raw binary payload를 그대로 붙여 직렬화하는 serializer입니다.
+/// </summary>
+public sealed class RawHexSerializer : ISerializer
+{
+    private const char Separator = '|';
+    private const byte SeparatorByte = (byte)Separator;
+
+    /// <summary>
+    /// binary payload 또는 hex text body를 raw payload로 변환해 직렬화합니다.
+    /// </summary>
+    /// <param name="message">직렬화할 메시지입니다.</param>
+    /// <returns>헤더와 raw payload가 결합된 바이트 배열입니다.</returns>
+    public byte[] Serialize(IMessage message)
+    {
+        var header = CreateHeader(message);
+        var payload = ExtractPayload(message);
+        var serialized = new byte[header.Length + payload.Length];
+        header.CopyTo(serialized, 0);
+        payload.CopyTo(serialized.AsSpan(header.Length));
+        return serialized;
+    }
+
+    /// <summary>
+    /// 헤더와 raw payload가 결합된 바이트 배열을 binary-capable 메시지로 복원합니다.
+    /// </summary>
+    /// <param name="payload">역직렬화할 바이트 배열입니다.</param>
+    /// <returns>복원된 binary 메시지입니다.</returns>
+    public IMessage Deserialize(ReadOnlySpan<byte> payload)
+    {
+        var index = 0;
+        var shape = ReadToken(payload, ref index, "message shape");
+        var messageIdToken = ReadToken(payload, ref index, "message id");
+        if (!ushort.TryParse(messageIdToken, NumberStyles.None, CultureInfo.InvariantCulture, out var messageId))
+        {
+            throw new InvalidOperationException("Payload does not contain a valid message id.");
+        }
+
+        return shape switch
+        {
+            "message" => new BinaryMessageModel(messageId, payload[index..].ToArray()),
+            "request" => DeserializeRequest(payload, index, messageId),
+            "response" => DeserializeResponse(payload, index, messageId),
+            _ => throw new InvalidOperationException("Payload does not contain a supported message shape.")
+        };
+    }
+
+    private static byte[] CreateHeader(IMessage message)
+    {
+        var header = message switch
+        {
+            IResponseMessage response => string.Create(
+                CultureInfo.InvariantCulture,
+                $"response|{message.MessageId}|{response.CorrelationId:D}|{(response.IsSuccess ? "1" : "0")}|"),
+            IRequestMessage request => string.Create(
+                CultureInfo.InvariantCulture,
+                $"request|{message.MessageId}|{request.CorrelationId:D}|"),
+            _ => string.Create(
+                CultureInfo.InvariantCulture,
+                $"message|{message.MessageId}|")
+        };
+
+        return Encoding.ASCII.GetBytes(header);
+    }
+
+    private static byte[] ExtractPayload(IMessage message)
+    {
+        if (message is IBinaryMessagePayload binaryPayload)
+        {
+            return binaryPayload.Payload.ToArray();
+        }
+
+        if (message is IMessageBody bodyMessage)
+        {
+            try
+            {
+                return HexPayloadParser.Parse(bodyMessage.Body);
+            }
+            catch (FormatException exception)
+            {
+                throw new InvalidOperationException("Message body must be valid hexadecimal text.", exception);
+            }
+        }
+
+        return [];
+    }
+
+    private static IMessage DeserializeRequest(ReadOnlySpan<byte> payload, int index, ushort messageId)
+    {
+        var correlationToken = ReadToken(payload, ref index, "correlation id");
+        if (!Guid.TryParseExact(correlationToken, "D", out var correlationId))
+        {
+            throw new InvalidOperationException("Payload does not contain a valid correlation id.");
+        }
+
+        return new BinaryRequestMessageModel(messageId, correlationId, payload[index..].ToArray());
+    }
+
+    private static IMessage DeserializeResponse(ReadOnlySpan<byte> payload, int index, ushort messageId)
+    {
+        var correlationToken = ReadToken(payload, ref index, "correlation id");
+        if (!Guid.TryParseExact(correlationToken, "D", out var correlationId))
+        {
+            throw new InvalidOperationException("Payload does not contain a valid correlation id.");
+        }
+
+        var successToken = ReadToken(payload, ref index, "success flag");
+        var isSuccess = successToken switch
+        {
+            "1" => true,
+            "0" => false,
+            _ => throw new InvalidOperationException("Payload does not contain a valid success flag.")
+        };
+
+        return new BinaryResponseMessageModel(messageId, correlationId, isSuccess, payload[index..].ToArray());
+    }
+
+    private static string ReadToken(ReadOnlySpan<byte> payload, ref int index, string fieldName)
+    {
+        var remaining = payload[index..];
+        var separatorIndex = remaining.IndexOf(SeparatorByte);
+        if (separatorIndex < 0)
+        {
+            throw new InvalidOperationException($"Payload does not contain a valid {fieldName}.");
+        }
+
+        var token = Encoding.ASCII.GetString(remaining[..separatorIndex]);
+        index += separatorIndex + 1;
+        return token;
+    }
+}

--- a/tests/CommLib.Infrastructure.Tests/RawHexConnectionManagerRoundtripTests.cs
+++ b/tests/CommLib.Infrastructure.Tests/RawHexConnectionManagerRoundtripTests.cs
@@ -1,0 +1,110 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using CommLib.Domain.Configuration;
+using CommLib.Domain.Messaging;
+using CommLib.Infrastructure.Factories;
+using CommLib.Infrastructure.Sessions;
+using Xunit;
+
+namespace CommLib.Infrastructure.Tests;
+
+/// <summary>
+/// 실제 TCP transport/session 경로에서 raw-hex serializer roundtrip이 유지되는지 검증합니다.
+/// </summary>
+public sealed class RawHexConnectionManagerRoundtripTests
+{
+    [Fact]
+    public async Task SendAndReceiveAsync_WithBinaryMessage_RoundTripsRawPayloadThroughTcpEcho()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var echoTask = EchoSingleLengthPrefixedFrameAsync(listener);
+
+        await using var manager = CreateManager();
+        var profile = CreateRawHexTcpProfile(((IPEndPoint)listener.LocalEndpoint).Port);
+        var outbound = new BinaryMessageModel(21, new byte[] { 0xDE, 0xAD, 0x00, 0x7C, 0xFF });
+
+        await manager.ConnectAsync(profile);
+        await manager.SendAsync(profile.DeviceId, outbound);
+
+        var inbound = Assert.IsType<BinaryMessageModel>(
+            await manager.ReceiveAsync(profile.DeviceId).WaitAsync(TimeSpan.FromSeconds(1)));
+
+        Assert.Equal(outbound.MessageId, inbound.MessageId);
+        Assert.Equal(outbound.Payload.ToArray(), inbound.Payload.ToArray());
+        Assert.Equal("DE AD 00 7C FF", MessagePayloadFormatter.FormatBody(inbound));
+        await echoTask.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task SendAndReceiveAsync_WithHexTextBody_BridgesToBinaryMessageThroughTcpEcho()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var echoTask = EchoSingleLengthPrefixedFrameAsync(listener);
+
+        await using var manager = CreateManager();
+        var profile = CreateRawHexTcpProfile(((IPEndPoint)listener.LocalEndpoint).Port);
+
+        await manager.ConnectAsync(profile);
+        await manager.SendAsync(profile.DeviceId, new MessageModel(22, "de ad 00 7c ff"));
+
+        var inbound = Assert.IsType<BinaryMessageModel>(
+            await manager.ReceiveAsync(profile.DeviceId).WaitAsync(TimeSpan.FromSeconds(1)));
+
+        Assert.Equal((ushort)22, inbound.MessageId);
+        Assert.Equal(new byte[] { 0xDE, 0xAD, 0x00, 0x7C, 0xFF }, inbound.Payload.ToArray());
+        Assert.Equal("DE AD 00 7C FF", MessagePayloadFormatter.FormatBody(inbound));
+        await echoTask.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    private static async Task EchoSingleLengthPrefixedFrameAsync(TcpListener listener)
+    {
+        using var client = await listener.AcceptTcpClientAsync().ConfigureAwait(false);
+        using var stream = client.GetStream();
+        var header = new byte[4];
+
+        await stream.ReadExactlyAsync(header).ConfigureAwait(false);
+        var payloadLength = BinaryPrimitives.ReadInt32BigEndian(header);
+        var payload = new byte[payloadLength];
+        await stream.ReadExactlyAsync(payload).ConfigureAwait(false);
+        await stream.WriteAsync(header).ConfigureAwait(false);
+        await stream.WriteAsync(payload).ConfigureAwait(false);
+    }
+
+    private static ConnectionManager CreateManager()
+    {
+        return new ConnectionManager(
+            new TransportFactory(),
+            new ProtocolFactory(),
+            new SerializerFactory());
+    }
+
+    private static DeviceProfile CreateRawHexTcpProfile(int port)
+    {
+        return new DeviceProfile
+        {
+            DeviceId = "rawhex-device",
+            DisplayName = "rawhex-device",
+            Enabled = true,
+            Transport = new TcpClientTransportOptions
+            {
+                Type = "TcpClient",
+                Host = IPAddress.Loopback.ToString(),
+                Port = port,
+                ConnectTimeoutMs = 1000,
+                BufferSize = 1024,
+                NoDelay = true
+            },
+            Protocol = new ProtocolOptions
+            {
+                Type = "LengthPrefixed"
+            },
+            Serializer = new SerializerOptions
+            {
+                Type = SerializerTypes.RawHex
+            }
+        };
+    }
+}

--- a/tests/CommLib.Infrastructure.Tests/RawHexSerializerTests.cs
+++ b/tests/CommLib.Infrastructure.Tests/RawHexSerializerTests.cs
@@ -1,0 +1,75 @@
+using System.Text;
+using CommLib.Domain.Messaging;
+using CommLib.Infrastructure.Protocol;
+using Xunit;
+
+namespace CommLib.Infrastructure.Tests;
+
+/// <summary>
+/// RawHex serializer가 binary payload와 hex text bridge를 올바르게 처리하는지 검증합니다.
+/// </summary>
+public sealed class RawHexSerializerTests
+{
+    [Fact]
+    public void Serialize_BinaryMessage_AppendsRawPayloadAfterHeader()
+    {
+        var serializer = new RawHexSerializer();
+        var message = new BinaryMessageModel(12, new byte[] { 0xDE, 0xAD, 0xBE, 0xEF });
+
+        var payload = serializer.Serialize(message);
+
+        Assert.Equal(
+            Encoding.ASCII.GetBytes("message|12|").Concat(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }).ToArray(),
+            payload);
+    }
+
+    [Fact]
+    public void Serialize_TextBodyHex_ParsesHexAndAppendsRawPayload()
+    {
+        var serializer = new RawHexSerializer();
+
+        var payload = serializer.Serialize(new MessageModel(12, "DE AD be ef"));
+
+        Assert.Equal(
+            Encoding.ASCII.GetBytes("message|12|").Concat(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }).ToArray(),
+            payload);
+    }
+
+    [Fact]
+    public void Deserialize_MessagePayload_ReturnsBinaryMessage()
+    {
+        var serializer = new RawHexSerializer();
+        var payload = Encoding.ASCII.GetBytes("message|12|").Concat(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }).ToArray();
+
+        var message = Assert.IsType<BinaryMessageModel>(serializer.Deserialize(payload));
+
+        Assert.Equal((ushort)12, message.MessageId);
+        Assert.Equal(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }, message.Payload.ToArray());
+    }
+
+    [Fact]
+    public void Deserialize_ResponsePayload_ReturnsBinaryResponseMessage()
+    {
+        var serializer = new RawHexSerializer();
+        var correlationId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+        var payload = Encoding.ASCII
+            .GetBytes($"response|9|{correlationId:D}|1|")
+            .Concat(new byte[] { 0x01, 0x02, 0x03 })
+            .ToArray();
+
+        var message = Assert.IsType<BinaryResponseMessageModel>(serializer.Deserialize(payload));
+
+        Assert.Equal((ushort)9, message.MessageId);
+        Assert.Equal(correlationId, message.CorrelationId);
+        Assert.True(message.IsSuccess);
+        Assert.Equal(new byte[] { 0x01, 0x02, 0x03 }, message.Payload.ToArray());
+    }
+
+    [Fact]
+    public void Serialize_InvalidHexBody_Throws()
+    {
+        var serializer = new RawHexSerializer();
+
+        Assert.Throws<InvalidOperationException>(() => serializer.Serialize(new MessageModel(12, "GG")));
+    }
+}

--- a/tests/CommLib.Infrastructure.Tests/SerializerFactoryTests.cs
+++ b/tests/CommLib.Infrastructure.Tests/SerializerFactoryTests.cs
@@ -24,6 +24,19 @@ public sealed class SerializerFactoryTests
     }
 
     /// <summary>
+    /// RawHex 설정이면 raw-hex serializer 구현을 생성하는지 확인합니다.
+    /// </summary>
+    [Fact]
+    public void Create_RawHexOptions_ReturnsRawHexSerializer()
+    {
+        var factory = new SerializerFactory();
+
+        var serializer = factory.Create(new SerializerOptions { Type = "RawHex" });
+
+        Assert.IsType<RawHexSerializer>(serializer);
+    }
+
+    /// <summary>
     /// 지원하지 않는 serializer 형식이면 예외를 던지는지 확인합니다.
     /// </summary>
     [Fact]

--- a/tests/CommLib.Unit.Tests/BitFieldCodecTests.cs
+++ b/tests/CommLib.Unit.Tests/BitFieldCodecTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace CommLib.Unit.Tests;
 
 /// <summary>
-/// raw payload bitfield codec가 비트 오프셋 기준 read/write를 올바르게 수행하는지 검증합니다.
+/// Verifies that the low-level bitfield codec reads and writes payload bits correctly.
 /// </summary>
 public sealed class BitFieldCodecTests
 {
@@ -39,6 +39,36 @@ public sealed class BitFieldCodecTests
     }
 
     [Fact]
+    public void ReadUnsigned_BigEndianWholeByteField_ReturnsExpectedValue()
+    {
+        var field = new BitFieldDefinition("register", 0, 16, BitFieldEndianness.BigEndian);
+
+        var value = BitFieldCodec.ReadUnsigned(new byte[] { 0x12, 0x34 }, field);
+
+        Assert.Equal(0x1234UL, value);
+    }
+
+    [Fact]
+    public void ReadUnsigned_BigEndianWholeByteFieldAtOffset_ReturnsExpectedValue()
+    {
+        var field = new BitFieldDefinition("register", 8, 16, BitFieldEndianness.BigEndian);
+
+        var value = BitFieldCodec.ReadUnsigned(new byte[] { 0xAA, 0x12, 0x34, 0xBB }, field);
+
+        Assert.Equal(0x1234UL, value);
+    }
+
+    [Fact]
+    public void ReadSigned_BigEndianWholeByteField_SignExtendsValue()
+    {
+        var field = new BitFieldDefinition("delta", 0, 16, BitFieldEndianness.BigEndian);
+
+        var value = BitFieldCodec.ReadSigned(new byte[] { 0xFF, 0x9C }, field);
+
+        Assert.Equal(-100, value);
+    }
+
+    [Fact]
     public void WriteUnsigned_FieldAcrossByteBoundary_WritesExpectedBitsOnly()
     {
         var field = new BitFieldDefinition("temperatureRaw", 4, 12);
@@ -47,6 +77,28 @@ public sealed class BitFieldCodecTests
         BitFieldCodec.WriteUnsigned(payload, field, 0xABC);
 
         Assert.Equal(new byte[] { 0xCF, 0xAB, 0xF0 }, payload);
+    }
+
+    [Fact]
+    public void WriteUnsigned_BigEndianWholeByteField_WritesMostSignificantByteFirst()
+    {
+        var field = new BitFieldDefinition("register", 0, 16, BitFieldEndianness.BigEndian);
+        var payload = new byte[2];
+
+        BitFieldCodec.WriteUnsigned(payload, field, 0x1234);
+
+        Assert.Equal(new byte[] { 0x12, 0x34 }, payload);
+    }
+
+    [Fact]
+    public void WriteUnsigned_BigEndianWholeByteFieldAtOffset_PreservesSurroundingBytes()
+    {
+        var field = new BitFieldDefinition("register", 8, 16, BitFieldEndianness.BigEndian);
+        var payload = new byte[] { 0xAA, 0x00, 0x00, 0xBB };
+
+        BitFieldCodec.WriteUnsigned(payload, field, 0x1234);
+
+        Assert.Equal(new byte[] { 0xAA, 0x12, 0x34, 0xBB }, payload);
     }
 
     [Fact]
@@ -68,5 +120,13 @@ public sealed class BitFieldCodecTests
         var exception = Assert.Throws<ArgumentOutOfRangeException>(() => BitFieldCodec.ReadUnsigned(new byte[] { 0x00, 0x01 }, field));
 
         Assert.Contains("status", exception.Message);
+    }
+
+    [Fact]
+    public void Ctor_BigEndianMultiByteFieldWithoutWholeBytes_Throws()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => new BitFieldDefinition("bad", 4, 12, BitFieldEndianness.BigEndian));
+
+        Assert.Contains("byte-aligned", exception.Message);
     }
 }

--- a/tests/CommLib.Unit.Tests/BitFieldCodecTests.cs
+++ b/tests/CommLib.Unit.Tests/BitFieldCodecTests.cs
@@ -1,0 +1,72 @@
+using CommLib.Domain.Messaging;
+using Xunit;
+
+namespace CommLib.Unit.Tests;
+
+/// <summary>
+/// raw payload bitfield codec가 비트 오프셋 기준 read/write를 올바르게 수행하는지 검증합니다.
+/// </summary>
+public sealed class BitFieldCodecTests
+{
+    [Fact]
+    public void ReadUnsigned_SingleBitField_ReturnsExpectedValue()
+    {
+        var field = new BitFieldDefinition("ready", 4, 1);
+
+        var value = BitFieldCodec.ReadUnsigned(new byte[] { 0b_0001_0000 }, field);
+
+        Assert.Equal(1UL, value);
+    }
+
+    [Fact]
+    public void ReadUnsigned_FieldAcrossByteBoundary_ReturnsExpectedValue()
+    {
+        var field = new BitFieldDefinition("temperatureRaw", 0, 12);
+
+        var value = BitFieldCodec.ReadUnsigned(new byte[] { 0xBC, 0x0A }, field);
+
+        Assert.Equal(0xABCUL, value);
+    }
+
+    [Fact]
+    public void ReadSigned_NegativeField_SignExtendsValue()
+    {
+        var field = new BitFieldDefinition("delta", 0, 12);
+
+        var value = BitFieldCodec.ReadSigned(new byte[] { 0x9C, 0x0F }, field);
+
+        Assert.Equal(-100, value);
+    }
+
+    [Fact]
+    public void WriteUnsigned_FieldAcrossByteBoundary_WritesExpectedBitsOnly()
+    {
+        var field = new BitFieldDefinition("temperatureRaw", 4, 12);
+        var payload = new byte[] { 0x0F, 0x00, 0xF0 };
+
+        BitFieldCodec.WriteUnsigned(payload, field, 0xABC);
+
+        Assert.Equal(new byte[] { 0xCF, 0xAB, 0xF0 }, payload);
+    }
+
+    [Fact]
+    public void WriteUnsigned_ValueTooLarge_Throws()
+    {
+        var field = new BitFieldDefinition("mode", 0, 3);
+        var payload = new byte[1];
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => BitFieldCodec.WriteUnsigned(payload, field, 0b1000));
+
+        Assert.Contains("mode", exception.Message);
+    }
+
+    [Fact]
+    public void ReadUnsigned_FieldOutsidePayload_Throws()
+    {
+        var field = new BitFieldDefinition("status", 12, 8);
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => BitFieldCodec.ReadUnsigned(new byte[] { 0x00, 0x01 }, field));
+
+        Assert.Contains("status", exception.Message);
+    }
+}

--- a/tests/CommLib.Unit.Tests/BitFieldPayloadSchemaCodecTests.cs
+++ b/tests/CommLib.Unit.Tests/BitFieldPayloadSchemaCodecTests.cs
@@ -1,0 +1,97 @@
+using CommLib.Domain.Messaging;
+using Xunit;
+
+namespace CommLib.Unit.Tests;
+
+/// <summary>
+/// bitfield payload schema codec가 named field 값을 raw payload로 compose/inspect하는지 검증합니다.
+/// </summary>
+public sealed class BitFieldPayloadSchemaCodecTests
+{
+    [Fact]
+    public void Compose_SignedAndUnsignedFields_ReturnsExpectedPayload()
+    {
+        var payload = BitFieldPayloadSchemaCodec.Compose(
+            CreateSchema(),
+            new[]
+            {
+                new BitFieldFieldAssignment("mode", 5),
+                new BitFieldFieldAssignment("enabled", 1),
+                new BitFieldFieldAssignment("delta", -100)
+            });
+
+        Assert.Equal(new byte[] { 0xCD, 0xF9 }, payload);
+    }
+
+    [Fact]
+    public void Inspect_SignedAndUnsignedFields_ReturnsExpectedValues()
+    {
+        var values = BitFieldPayloadSchemaCodec.Inspect(CreateSchema(), new byte[] { 0xCD, 0xF9 });
+
+        Assert.Collection(
+            values,
+            item =>
+            {
+                Assert.Equal("mode", item.Field.Name);
+                Assert.Equal(BitFieldScalarKind.Unsigned, item.ScalarKind);
+                Assert.Equal(5m, item.Value);
+            },
+            item =>
+            {
+                Assert.Equal("enabled", item.Field.Name);
+                Assert.Equal(BitFieldScalarKind.Unsigned, item.ScalarKind);
+                Assert.Equal(1m, item.Value);
+            },
+            item =>
+            {
+                Assert.Equal("delta", item.Field.Name);
+                Assert.Equal(BitFieldScalarKind.Signed, item.ScalarKind);
+                Assert.Equal(-100m, item.Value);
+            });
+    }
+
+    [Fact]
+    public void Compose_UnknownField_Throws()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => BitFieldPayloadSchemaCodec.Compose(
+                CreateSchema(),
+                new[] { new BitFieldFieldAssignment("unknown", 1) }));
+
+        Assert.Contains("unknown", exception.Message);
+    }
+
+    [Fact]
+    public void Compose_FractionalValue_Throws()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => BitFieldPayloadSchemaCodec.Compose(
+                CreateSchema(),
+                new[] { new BitFieldFieldAssignment("mode", 1.5m) }));
+
+        Assert.Contains("integer", exception.Message);
+    }
+
+    [Fact]
+    public void Inspect_PayloadLengthMismatch_Throws()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => BitFieldPayloadSchemaCodec.Inspect(CreateSchema(), new byte[] { 0xCD }));
+
+        Assert.Contains("does not match", exception.Message);
+    }
+
+    private static BitFieldPayloadSchema CreateSchema()
+    {
+        return new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 2,
+            Fields = new[]
+            {
+                new BitFieldPayloadField { Name = "mode", BitOffset = 0, BitLength = 3 },
+                new BitFieldPayloadField { Name = "enabled", BitOffset = 3, BitLength = 1 },
+                new BitFieldPayloadField { Name = "delta", BitOffset = 4, BitLength = 12, ScalarKind = BitFieldScalarKind.Signed }
+            }
+        };
+    }
+}

--- a/tests/CommLib.Unit.Tests/BitFieldPayloadSchemaCodecTests.cs
+++ b/tests/CommLib.Unit.Tests/BitFieldPayloadSchemaCodecTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace CommLib.Unit.Tests;
 
 /// <summary>
-/// bitfield payload schema codec가 named field 값을 raw payload로 compose/inspect하는지 검증합니다.
+/// Verifies that the schema-backed payload codec can compose and inspect named fields.
 /// </summary>
 public sealed class BitFieldPayloadSchemaCodecTests
 {
@@ -12,7 +12,7 @@ public sealed class BitFieldPayloadSchemaCodecTests
     public void Compose_SignedAndUnsignedFields_ReturnsExpectedPayload()
     {
         var payload = BitFieldPayloadSchemaCodec.Compose(
-            CreateSchema(),
+            CreateLittleEndianSchema(),
             new[]
             {
                 new BitFieldFieldAssignment("mode", 5),
@@ -26,7 +26,7 @@ public sealed class BitFieldPayloadSchemaCodecTests
     [Fact]
     public void Inspect_SignedAndUnsignedFields_ReturnsExpectedValues()
     {
-        var values = BitFieldPayloadSchemaCodec.Inspect(CreateSchema(), new byte[] { 0xCD, 0xF9 });
+        var values = BitFieldPayloadSchemaCodec.Inspect(CreateLittleEndianSchema(), new byte[] { 0xCD, 0xF9 });
 
         Assert.Collection(
             values,
@@ -51,11 +51,90 @@ public sealed class BitFieldPayloadSchemaCodecTests
     }
 
     [Fact]
+    public void Compose_BigEndianWholeByteField_ReturnsExpectedPayload()
+    {
+        var payload = BitFieldPayloadSchemaCodec.Compose(
+            CreateBigEndianSchema(),
+            new[]
+            {
+                new BitFieldFieldAssignment("register", 0x1234),
+                new BitFieldFieldAssignment("tail", 0xAB)
+            });
+
+        Assert.Equal(new byte[] { 0x12, 0x34, 0xAB }, payload);
+    }
+
+    [Fact]
+    public void Inspect_BigEndianWholeByteField_ReturnsExpectedValues()
+    {
+        var values = BitFieldPayloadSchemaCodec.Inspect(CreateBigEndianSchema(), new byte[] { 0x12, 0x34, 0xAB });
+
+        Assert.Collection(
+            values,
+            item =>
+            {
+                Assert.Equal("register", item.Field.Name);
+                Assert.Equal(BitFieldEndianness.BigEndian, item.Field.Endianness);
+                Assert.Equal(4660m, item.Value);
+            },
+            item =>
+            {
+                Assert.Equal("tail", item.Field.Name);
+                Assert.Equal(BitFieldEndianness.LittleEndian, item.Field.Endianness);
+                Assert.Equal(171m, item.Value);
+            });
+    }
+
+    [Fact]
+    public void Compose_MixedEndianSchemaWithOffsetAndSignedField_ReturnsExpectedPayload()
+    {
+        var payload = BitFieldPayloadSchemaCodec.Compose(
+            CreateMixedEndianSchema(),
+            new[]
+            {
+                new BitFieldFieldAssignment("prefix", 0xAA),
+                new BitFieldFieldAssignment("register", 0x1234),
+                new BitFieldFieldAssignment("delta", -100)
+            });
+
+        Assert.Equal(new byte[] { 0xAA, 0x12, 0x34, 0xFF, 0x9C }, payload);
+    }
+
+    [Fact]
+    public void Inspect_MixedEndianSchemaWithOffsetAndSignedField_ReturnsExpectedValues()
+    {
+        var values = BitFieldPayloadSchemaCodec.Inspect(
+            CreateMixedEndianSchema(),
+            new byte[] { 0xAA, 0x12, 0x34, 0xFF, 0x9C });
+
+        Assert.Collection(
+            values,
+            item =>
+            {
+                Assert.Equal("prefix", item.Field.Name);
+                Assert.Equal(170m, item.Value);
+            },
+            item =>
+            {
+                Assert.Equal("register", item.Field.Name);
+                Assert.Equal(BitFieldEndianness.BigEndian, item.Field.Endianness);
+                Assert.Equal(4660m, item.Value);
+            },
+            item =>
+            {
+                Assert.Equal("delta", item.Field.Name);
+                Assert.Equal(BitFieldScalarKind.Signed, item.ScalarKind);
+                Assert.Equal(BitFieldEndianness.BigEndian, item.Field.Endianness);
+                Assert.Equal(-100m, item.Value);
+            });
+    }
+
+    [Fact]
     public void Compose_UnknownField_Throws()
     {
         var exception = Assert.Throws<InvalidOperationException>(
             () => BitFieldPayloadSchemaCodec.Compose(
-                CreateSchema(),
+                CreateLittleEndianSchema(),
                 new[] { new BitFieldFieldAssignment("unknown", 1) }));
 
         Assert.Contains("unknown", exception.Message);
@@ -66,7 +145,7 @@ public sealed class BitFieldPayloadSchemaCodecTests
     {
         var exception = Assert.Throws<InvalidOperationException>(
             () => BitFieldPayloadSchemaCodec.Compose(
-                CreateSchema(),
+                CreateLittleEndianSchema(),
                 new[] { new BitFieldFieldAssignment("mode", 1.5m) }));
 
         Assert.Contains("integer", exception.Message);
@@ -76,12 +155,12 @@ public sealed class BitFieldPayloadSchemaCodecTests
     public void Inspect_PayloadLengthMismatch_Throws()
     {
         var exception = Assert.Throws<InvalidOperationException>(
-            () => BitFieldPayloadSchemaCodec.Inspect(CreateSchema(), new byte[] { 0xCD }));
+            () => BitFieldPayloadSchemaCodec.Inspect(CreateLittleEndianSchema(), new byte[] { 0xCD }));
 
         Assert.Contains("does not match", exception.Message);
     }
 
-    private static BitFieldPayloadSchema CreateSchema()
+    private static BitFieldPayloadSchema CreateLittleEndianSchema()
     {
         return new BitFieldPayloadSchema
         {
@@ -91,6 +170,62 @@ public sealed class BitFieldPayloadSchemaCodecTests
                 new BitFieldPayloadField { Name = "mode", BitOffset = 0, BitLength = 3 },
                 new BitFieldPayloadField { Name = "enabled", BitOffset = 3, BitLength = 1 },
                 new BitFieldPayloadField { Name = "delta", BitOffset = 4, BitLength = 12, ScalarKind = BitFieldScalarKind.Signed }
+            }
+        };
+    }
+
+    private static BitFieldPayloadSchema CreateBigEndianSchema()
+    {
+        return new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 3,
+            Fields = new[]
+            {
+                new BitFieldPayloadField
+                {
+                    Name = "register",
+                    BitOffset = 0,
+                    BitLength = 16,
+                    Endianness = BitFieldEndianness.BigEndian
+                },
+                new BitFieldPayloadField
+                {
+                    Name = "tail",
+                    BitOffset = 16,
+                    BitLength = 8
+                }
+            }
+        };
+    }
+
+    private static BitFieldPayloadSchema CreateMixedEndianSchema()
+    {
+        return new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 5,
+            Fields = new[]
+            {
+                new BitFieldPayloadField
+                {
+                    Name = "prefix",
+                    BitOffset = 0,
+                    BitLength = 8
+                },
+                new BitFieldPayloadField
+                {
+                    Name = "register",
+                    BitOffset = 8,
+                    BitLength = 16,
+                    Endianness = BitFieldEndianness.BigEndian
+                },
+                new BitFieldPayloadField
+                {
+                    Name = "delta",
+                    BitOffset = 24,
+                    BitLength = 16,
+                    ScalarKind = BitFieldScalarKind.Signed,
+                    Endianness = BitFieldEndianness.BigEndian
+                }
             }
         };
     }

--- a/tests/CommLib.Unit.Tests/BitFieldPayloadSchemaValidatorTests.cs
+++ b/tests/CommLib.Unit.Tests/BitFieldPayloadSchemaValidatorTests.cs
@@ -1,0 +1,63 @@
+using CommLib.Domain.Messaging;
+using Xunit;
+
+namespace CommLib.Unit.Tests;
+
+/// <summary>
+/// bitfield payload schema validator가 payload 길이, overlap, duplicate 조건을 검증하는지 확인합니다.
+/// </summary>
+public sealed class BitFieldPayloadSchemaValidatorTests
+{
+    [Fact]
+    public void ValidateAndThrow_FieldOutsidePayload_Throws()
+    {
+        var schema = new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 1,
+            Fields = new[]
+            {
+                new BitFieldPayloadField { Name = "status", BitOffset = 4, BitLength = 8 }
+            }
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BitFieldPayloadSchemaValidator.ValidateAndThrow(schema));
+
+        Assert.Contains("status", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateAndThrow_DuplicateFieldName_Throws()
+    {
+        var schema = new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 2,
+            Fields = new[]
+            {
+                new BitFieldPayloadField { Name = "mode", BitOffset = 0, BitLength = 3 },
+                new BitFieldPayloadField { Name = "mode", BitOffset = 8, BitLength = 3 }
+            }
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BitFieldPayloadSchemaValidator.ValidateAndThrow(schema));
+
+        Assert.Contains("duplicated", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateAndThrow_OverlappingFields_Throws()
+    {
+        var schema = new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 2,
+            Fields = new[]
+            {
+                new BitFieldPayloadField { Name = "mode", BitOffset = 0, BitLength = 8 },
+                new BitFieldPayloadField { Name = "delta", BitOffset = 4, BitLength = 8 }
+            }
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BitFieldPayloadSchemaValidator.ValidateAndThrow(schema));
+
+        Assert.Contains("overlap", exception.Message);
+    }
+}

--- a/tests/CommLib.Unit.Tests/BitFieldPayloadSchemaValidatorTests.cs
+++ b/tests/CommLib.Unit.Tests/BitFieldPayloadSchemaValidatorTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace CommLib.Unit.Tests;
 
 /// <summary>
-/// bitfield payload schema validator가 payload 길이, overlap, duplicate 조건을 검증하는지 확인합니다.
+/// Verifies that the payload schema validator catches invalid field layouts.
 /// </summary>
 public sealed class BitFieldPayloadSchemaValidatorTests
 {
@@ -59,5 +59,28 @@ public sealed class BitFieldPayloadSchemaValidatorTests
         var exception = Assert.Throws<InvalidOperationException>(() => BitFieldPayloadSchemaValidator.ValidateAndThrow(schema));
 
         Assert.Contains("overlap", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateAndThrow_BigEndianNonByteAlignedField_Throws()
+    {
+        var schema = new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 2,
+            Fields = new[]
+            {
+                new BitFieldPayloadField
+                {
+                    Name = "register",
+                    BitOffset = 4,
+                    BitLength = 12,
+                    Endianness = BitFieldEndianness.BigEndian
+                }
+            }
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BitFieldPayloadSchemaValidator.ValidateAndThrow(schema));
+
+        Assert.Contains("byte-aligned", exception.InnerException?.Message ?? exception.Message);
     }
 }

--- a/tests/CommLib.Unit.Tests/DeviceProfileMapperTests.cs
+++ b/tests/CommLib.Unit.Tests/DeviceProfileMapperTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using CommLib.Application.Configuration;
 using CommLib.Domain.Configuration;
+using CommLib.Domain.Messaging;
 using Xunit;
 
 namespace CommLib.Unit.Tests;
@@ -56,7 +57,18 @@ public sealed class DeviceProfileMapperTests
     {
         var json = "{ \"Type\": \"TcpClient\", \"Host\": \"127.0.0.1\", \"Port\": 9000 }";
         var protocol = new ProtocolOptions { Type = "LengthPrefixed", MaxFrameLength = 4096 };
-        var serializer = new SerializerOptions { Type = "Json" };
+        var serializer = new SerializerOptions
+        {
+            Type = "Json",
+            BitFieldSchema = new BitFieldPayloadSchema
+            {
+                PayloadLengthBytes = 2,
+                Fields = new[]
+                {
+                    new BitFieldPayloadField { Name = "mode", BitOffset = 0, BitLength = 3 }
+                }
+            }
+        };
         var reconnect = new ReconnectOptions { Type = "Linear", IntervalMs = 1500, MaxAttempts = 5 };
         var requestResponse = new RequestResponseOptions { MaxPendingRequests = 32, DefaultTimeoutMs = 2500 };
 
@@ -79,6 +91,7 @@ public sealed class DeviceProfileMapperTests
         Assert.False(profile.Enabled);
         Assert.Same(protocol, profile.Protocol);
         Assert.Same(serializer, profile.Serializer);
+        Assert.Same(serializer.BitFieldSchema, profile.Serializer.BitFieldSchema);
         Assert.Same(reconnect, profile.Reconnect);
         Assert.Same(requestResponse, profile.RequestResponse);
     }

--- a/tests/CommLib.Unit.Tests/DeviceProfileValidatorTests.cs
+++ b/tests/CommLib.Unit.Tests/DeviceProfileValidatorTests.cs
@@ -1,5 +1,6 @@
 using CommLib.Application.Configuration;
 using CommLib.Domain.Configuration;
+using CommLib.Domain.Messaging;
 using Xunit;
 
 namespace CommLib.Unit.Tests;
@@ -180,6 +181,64 @@ public sealed class DeviceProfileValidatorTests
         });
 
         Assert.Throws<InvalidOperationException>(() => DeviceProfileValidator.ValidateAndThrow(profile));
+    }
+
+    [Fact]
+    public void Validate_BitFieldSchemaWithAutoBinarySerializer_Throws()
+    {
+        var profile = CreateTcpProfile(deviceId: "tcp-03bb", displayName: "TCP 03BB", host: "127.0.0.1", port: 502);
+        profile = new DeviceProfile
+        {
+            DeviceId = profile.DeviceId,
+            DisplayName = profile.DisplayName,
+            Enabled = profile.Enabled,
+            Transport = profile.Transport,
+            Protocol = profile.Protocol,
+            Serializer = new SerializerOptions
+            {
+                Type = SerializerTypes.AutoBinary,
+                BitFieldSchema = CreateValidBitFieldSchema()
+            },
+            Reconnect = profile.Reconnect,
+            RequestResponse = profile.RequestResponse
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => DeviceProfileValidator.ValidateAndThrow(profile));
+
+        Assert.Contains("RawHex", exception.Message);
+    }
+
+    [Fact]
+    public void Validate_InvalidBitFieldSchema_Throws()
+    {
+        var profile = CreateTcpProfile(deviceId: "tcp-03bc", displayName: "TCP 03BC", host: "127.0.0.1", port: 502);
+        profile = new DeviceProfile
+        {
+            DeviceId = profile.DeviceId,
+            DisplayName = profile.DisplayName,
+            Enabled = profile.Enabled,
+            Transport = profile.Transport,
+            Protocol = profile.Protocol,
+            Serializer = new SerializerOptions
+            {
+                Type = SerializerTypes.RawHex,
+                BitFieldSchema = new BitFieldPayloadSchema
+                {
+                    PayloadLengthBytes = 1,
+                    Fields = new[]
+                    {
+                        new BitFieldPayloadField { Name = "mode", BitOffset = 0, BitLength = 6 },
+                        new BitFieldPayloadField { Name = "status", BitOffset = 4, BitLength = 4 }
+                    }
+                }
+            },
+            Reconnect = profile.Reconnect,
+            RequestResponse = profile.RequestResponse
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => DeviceProfileValidator.ValidateAndThrow(profile));
+
+        Assert.Contains("BitFieldSchema", exception.Message);
     }
 
     [Fact]
@@ -540,6 +599,19 @@ public sealed class DeviceProfileValidatorTests
             Serializer = profile.Serializer,
             Reconnect = reconnect,
             RequestResponse = profile.RequestResponse
+        };
+    }
+
+    private static BitFieldPayloadSchema CreateValidBitFieldSchema()
+    {
+        return new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 2,
+            Fields = new[]
+            {
+                new BitFieldPayloadField { Name = "mode", BitOffset = 0, BitLength = 3 },
+                new BitFieldPayloadField { Name = "delta", BitOffset = 4, BitLength = 12, ScalarKind = BitFieldScalarKind.Signed }
+            }
         };
     }
 

--- a/tests/CommLib.Unit.Tests/MessagePayloadFormatterTests.cs
+++ b/tests/CommLib.Unit.Tests/MessagePayloadFormatterTests.cs
@@ -1,0 +1,36 @@
+using CommLib.Domain.Messaging;
+using Xunit;
+
+namespace CommLib.Unit.Tests;
+
+/// <summary>
+/// 메시지 payload 표시 포맷터가 text와 binary 메시지를 모두 다루는지 검증합니다.
+/// </summary>
+public sealed class MessagePayloadFormatterTests
+{
+    [Fact]
+    public void FormatBody_TextMessage_ReturnsTextBody()
+    {
+        var body = MessagePayloadFormatter.FormatBody(new MessageModel(10, "hello"));
+
+        Assert.Equal("hello", body);
+    }
+
+    [Fact]
+    public void FormatBody_BinaryMessage_ReturnsUppercaseHex()
+    {
+        var body = MessagePayloadFormatter.FormatBody(new BinaryMessageModel(10, new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }));
+
+        Assert.Equal("DE AD BE EF", body);
+    }
+
+    [Fact]
+    public void FormatBody_MessageWithoutPayload_ReturnsEmptyString()
+    {
+        var body = MessagePayloadFormatter.FormatBody(new NoPayloadMessage(10));
+
+        Assert.Equal(string.Empty, body);
+    }
+
+    private sealed record NoPayloadMessage(ushort MessageId) : IMessage;
+}

--- a/tests/CommLib.Unit.Tests/MessagePayloadFormatterTests.cs
+++ b/tests/CommLib.Unit.Tests/MessagePayloadFormatterTests.cs
@@ -32,5 +32,53 @@ public sealed class MessagePayloadFormatterTests
         Assert.Equal(string.Empty, body);
     }
 
+    [Fact]
+    public void TryFormatBitFieldSummary_BigEndianSchemaAtOffset_ReturnsFieldSummary()
+    {
+        var message = new BinaryMessageModel(10, new byte[] { 0xAA, 0x12, 0x34, 0x7F });
+        var schema = new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 4,
+            Fields = new[]
+            {
+                new BitFieldPayloadField { Name = "prefix", BitOffset = 0, BitLength = 8 },
+                new BitFieldPayloadField
+                {
+                    Name = "register",
+                    BitOffset = 8,
+                    BitLength = 16,
+                    Endianness = BitFieldEndianness.BigEndian
+                },
+                new BitFieldPayloadField { Name = "tail", BitOffset = 24, BitLength = 8 }
+            }
+        };
+
+        var result = MessagePayloadFormatter.TryFormatBitFieldSummary(message, schema, out var summary, out var error);
+
+        Assert.True(result);
+        Assert.Equal("prefix=170, register=4660, tail=127", summary);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void TryFormatBitFieldSummary_PayloadLengthMismatch_ReturnsErrorWithoutThrowing()
+    {
+        var message = new BinaryMessageModel(10, new byte[] { 0x12 });
+        var schema = new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 2,
+            Fields = new[]
+            {
+                new BitFieldPayloadField { Name = "register", BitOffset = 0, BitLength = 16 }
+            }
+        };
+
+        var result = MessagePayloadFormatter.TryFormatBitFieldSummary(message, schema, out var summary, out var error);
+
+        Assert.False(result);
+        Assert.Null(summary);
+        Assert.Contains("does not match", error);
+    }
+
     private sealed record NoPayloadMessage(ushort MessageId) : IMessage;
 }

--- a/tests/CommLib.Unit.Tests/OutboundMessageComposerTests.cs
+++ b/tests/CommLib.Unit.Tests/OutboundMessageComposerTests.cs
@@ -47,8 +47,35 @@ public sealed class OutboundMessageComposerTests
     }
 
     [Fact]
+    public void Compose_BitFieldSchema_ReturnsBinaryMessageModel()
+    {
+        var schema = new BitFieldPayloadSchema
+        {
+            PayloadLengthBytes = 2,
+            Fields = new[]
+            {
+                new BitFieldPayloadField { Name = "mode", BitOffset = 0, BitLength = 3 },
+                new BitFieldPayloadField { Name = "delta", BitOffset = 4, BitLength = 12, ScalarKind = BitFieldScalarKind.Signed }
+            }
+        };
+
+        var message = OutboundMessageComposer.Compose(
+            14,
+            schema,
+            new[]
+            {
+                new BitFieldFieldAssignment("mode", 5),
+                new BitFieldFieldAssignment("delta", -100)
+            });
+
+        var typed = Assert.IsType<BinaryMessageModel>(message);
+        Assert.Equal((ushort)14, typed.MessageId);
+        Assert.Equal(new byte[] { 0xC5, 0xF9 }, typed.Payload.ToArray());
+    }
+
+    [Fact]
     public void Compose_UnsupportedSerializer_ThrowsNotSupportedException()
     {
-        Assert.Throws<NotSupportedException>(() => OutboundMessageComposer.Compose("Custom", 14, "hello"));
+        Assert.Throws<NotSupportedException>(() => OutboundMessageComposer.Compose("Custom", 15, "hello"));
     }
 }

--- a/tests/CommLib.Unit.Tests/OutboundMessageComposerTests.cs
+++ b/tests/CommLib.Unit.Tests/OutboundMessageComposerTests.cs
@@ -1,0 +1,54 @@
+using CommLib.Application.Messaging;
+using CommLib.Domain.Configuration;
+using CommLib.Domain.Messaging;
+using Xunit;
+
+namespace CommLib.Unit.Tests;
+
+/// <summary>
+/// outbound message composer媛 serializer ?좏깮???곕씪 ?곸젅??硫붿떆吏 紐⑤뜽??留뚮뱶?붿? 寃利앺빀?덈떎.
+/// </summary>
+public sealed class OutboundMessageComposerTests
+{
+    [Fact]
+    public void Compose_AutoBinary_ReturnsTextMessageModel()
+    {
+        var message = OutboundMessageComposer.Compose(SerializerTypes.AutoBinary, 10, "hello");
+
+        var typed = Assert.IsType<MessageModel>(message);
+        Assert.Equal((ushort)10, typed.MessageId);
+        Assert.Equal("hello", typed.Body);
+    }
+
+    [Fact]
+    public void Compose_RawHex_ReturnsBinaryMessageModel()
+    {
+        var message = OutboundMessageComposer.Compose(SerializerTypes.RawHex, 11, "DE AD be ef");
+
+        var typed = Assert.IsType<BinaryMessageModel>(message);
+        Assert.Equal((ushort)11, typed.MessageId);
+        Assert.Equal(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }, typed.Payload.ToArray());
+    }
+
+    [Fact]
+    public void Compose_RawHexWithEmptyBody_ReturnsEmptyBinaryMessageModel()
+    {
+        var message = OutboundMessageComposer.Compose(SerializerTypes.RawHex, 12, "   ");
+
+        var typed = Assert.IsType<BinaryMessageModel>(message);
+        Assert.Equal((ushort)12, typed.MessageId);
+        Assert.Empty(typed.Payload.ToArray());
+    }
+
+    [Fact]
+    public void Compose_RawHexWithInvalidBody_ThrowsFormatException()
+    {
+        Assert.Throws<FormatException>(() => OutboundMessageComposer.Compose(SerializerTypes.RawHex, 13, "GG"));
+    }
+
+    [Fact]
+    public void Compose_UnsupportedSerializer_ThrowsNotSupportedException()
+    {
+        Assert.Throws<NotSupportedException>(() => OutboundMessageComposer.Compose("Custom", 14, "hello"));
+    }
+}


### PR DESCRIPTION
## Summary

This PR opens the base review line for the raw-hex and schema-backed bitfield work.
It introduces a binary-capable serializer path, config-backed bitfield schema support, and the first endian-aware whole-byte bitfield semantics.

A stacked follow-up PR is already open on top of this branch:
- #6 `feat(examples): enrich RawHex logs with bitfield schema summaries`

## What changed

### RawHex foundation
- add binary-capable message contracts and formatter support
- add `RawHexSerializer`
- extend `SerializerFactory` to create `RawHex`
- wire the WinUI example and console sample into the raw-hex compose/send path
- add focused raw-hex infrastructure coverage

### Schema-backed bitfield payload support
- add `BitFieldPayloadSchema`, `BitFieldPayloadField`, `BitFieldScalarKind`
- add schema validation and schema-backed compose/inspect helpers
- extend `SerializerOptions` so config can carry an optional bitfield schema
- enforce that schema usage is currently valid only with `RawHex`
- add schema-aware outbound message composition coverage

### Endian-aware whole-byte fields
- add `BitFieldEndianness`
- teach the low-level codec and schema-facing definitions to carry endianness metadata
- support `BigEndian` for byte-aligned multi-byte fields while preserving the existing `payload[0]` LSB = bit `0` rule
- keep MSB-first numbering and partial-byte big-endian multi-byte fields out of scope for now

## Validation

- `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --filter "BitFieldCodecTests|BitFieldPayloadSchemaCodecTests|BitFieldPayloadSchemaValidatorTests|OutboundMessageComposerTests|MessagePayloadFormatterTests|DeviceProfileValidatorTests"`
- `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --filter "RawHexSerializerTests|SerializerFactoryTests|RawHexConnectionManagerRoundtripTests"`
- `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`

## Scope notes

Included:
- raw-hex payload foundation
- schema-backed bitfield compose/inspect
- endian-aware whole-byte field semantics
- WinUI raw-hex wiring needed to exercise the base path

Excluded:
- in-app bitfield schema editor
- queue/hosting/runtime hardening work
- queue-pressure observability
- reconnect naming cleanup

## Review guidance

The most useful review lens here is whether the serializer/composer boundary is the right home for these capabilities. This PR intentionally avoids transport/protocol rewrites and keeps bitfield meaning above frame-boundary handling.
