### PR TITLE
[codex] clarify helper multicast loopback note

### DIFF
--- a/CHANGELOG_AGENT.md
+++ b/CHANGELOG_AGENT.md
@@ -256,3 +256,15 @@
 - Tightened the helper docs after design review without widening the implementation:
   - clarified in the WinUI and console READMEs that the helper currently matches the console sample's `AutoBinary` / `NoOpSerializer` contract rather than `RawHex`
   - switched the WinUI helper examples to `powershell -ExecutionPolicy Bypass -File ...` while noting that `pwsh` also works when PowerShell 7 is installed
+- Created GitHub issue `#12` after the live helper-backed multicast validation found one remaining operator-truthfulness gap:
+  - the runtime behavior was correct, but one-machine helper-backed multicast still let the WinUI live log show the app's own outbound payload as an inbound line when loopback was enabled
+  - that behavior came from issue `#11` validation evidence rather than from a new code bug
+- Started `docs/issue-12-multicast-loopback-wording` as a fresh worktree branch from `feat/issue-9-winui-transport-helper` instead of stacking the wording change onto the issue `#11` validation-only branch.
+- Kept the issue `#12` implementation as the smallest possible docs slice:
+  - updated only `examples/CommLib.Examples.WinUI/README.md`
+  - added a helper-section note that self-loopback inbound lines are expected during one-machine multicast validation
+  - added a small tip to use distinct helper/app message bodies when distinguishing helper traffic from looped-back app traffic
+- Published the wording branch for review:
+  - pushed `docs/issue-12-multicast-loopback-wording` to `commlib-hub`
+  - opened draft PR `#13`: `https://github.com/parksanghoon-sys/commlib-hub/pull/13`
+- No build or test rerun was needed for issue `#12` because the change is README-only and its wording is grounded in the already-completed live validation from issue `#11`.

--- a/CURRENT_PLAN.md
+++ b/CURRENT_PLAN.md
@@ -3,36 +3,36 @@
 Date: 2026-04-16
 
 ## Goal
-Close GitHub issue `#9` by adding a reusable local WinUI transport validation helper without widening into new transport/runtime contracts.
+Close GitHub issue `#12` with the smallest truthful helper-backed multicast wording fix, stacked on the helper branch without widening into runtime behavior or broader UI-copy changes.
 
 ## Confirmed Facts
-- This branch is `feat/issue-9-winui-transport-helper`, created from local `main` after the separate `commlib-codex-full` worktree was found dirty with preserved state-file edits.
-- GitHub issue `#9` now tracks this helper follow-up: `Add reusable local WinUI transport validation helper`.
-- Draft PR `#10` now carries this branch against `main`: `[codex] add WinUI transport validation helper`.
-- `examples/CommLib.Examples.WinUI/README.md` previously pointed contributors at ad-hoc `CommLib.Examples.Console` commands for local peer setup.
-- `examples/CommLib.Examples.Console` already contained the shared framing/serialization logic and multicast send/receive commands, so duplicating protocol behavior in PowerShell would be unnecessary.
-- The current implementation on this branch now adds:
-  - external-peer-only `tcp-echo-server` and `udp-echo-server` console commands
-  - `scripts/Start-WinUiTransportValidation.ps1` as the repo-owned entry point for TCP/UDP echo and multicast send/receive flows
-  - README guidance in both the WinUI and console examples
-- The helper docs are now explicit that this branch's helper path is currently `AutoBinary` / `NoOpSerializer` only; `RawHex` validation still needs the in-app mock or another RawHex-speaking peer.
-- Focused validation succeeded sequentially:
-  - `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj`
-  - `powershell -ExecutionPolicy Bypass -File scripts/Start-WinUiTransportValidation.ps1 -Mode TcpEcho -NoBuild -TimeoutMs 200`
-  - `powershell -ExecutionPolicy Bypass -File scripts/Start-WinUiTransportValidation.ps1 -Mode UdpEcho -NoBuild -TimeoutMs 200`
-  - `powershell -ExecutionPolicy Bypass -File scripts/Start-WinUiTransportValidation.ps1 -Mode MulticastSend -NoBuild -Port 7004 -Message "helper smoke"`
-- A focused `MulticastReceive` smoke without traffic still exits non-zero on timeout by design, and the README now calls that out explicitly.
+- This branch is `docs/issue-12-multicast-loopback-wording`, created as a new worktree branch from `feat/issue-9-winui-transport-helper` so the issue `#11` validation-only branch can stay untouched.
+- GitHub issue `#12` tracks this wording-only follow-up: `Clarify helper-backed multicast self-loopback behavior in WinUI validation docs`.
+- Draft PR `#13` now carries this branch against `feat/issue-9-winui-transport-helper`: `[codex] clarify helper multicast loopback note`.
+- The parent helper implementation still lives on GitHub issue `#9` and draft PR `#10`.
+- GitHub issue `#11` already proved the relevant runtime behavior before this branch was created:
+  - helper `MulticastSend` reaches the WinUI app as inbound traffic
+  - helper `MulticastReceive` captures the app outbound multicast frame
+  - on one machine with loopback enabled, the WinUI live log can also show an inbound copy of the app's own outbound payload
+- The issue `#12` change intentionally stays docs-only:
+  - no transport/session/runtime behavior changes
+  - no status-copy or localization changes in `AppLocalizer.cs`
+  - only `examples/CommLib.Examples.WinUI/README.md` was updated
+- The README now tells the truth about helper-backed one-machine multicast validation by:
+  - stating that the app can log its own outbound multicast payload as an `Inbound message`
+  - clarifying that this self-loopback line is expected rather than a helper failure
+  - suggesting distinct helper/app message bodies to distinguish helper traffic from looped-back app traffic quickly
 
 ## Next Work Unit
-1. Keep PR `#10` limited to the issue `#9` helper slice; do not widen it with live-validation findings or UI copy tweaks.
-2. In a later branch, run one live WinUI UDP / multicast validation pass using the new helper.
-3. If that pass still shows multicast operator confusion, handle the wording/UI follow-up as its own small branch.
+1. Keep PR `#13` reviewable as a wording-only stacked diff on top of PR `#10`.
+2. Do not widen this branch into additional localization/status-copy edits unless review shows the README-only clarification is insufficient.
+3. Leave the remaining real-pointer-only WinUI confidence question as a separate manual follow-up, not as something to fold into this docs slice.
 
 ## Next Slice Design
-1. Keep the helper implementation as a thin wrapper over the existing console sample rather than introducing a second framing implementation in PowerShell.
-2. Limit docs changes to the WinUI and console READMEs that directly explain the helper.
-3. Leave the remaining live UDP / multicast / real-pointer WinUI validation pass as a later follow-up that can now reuse this helper.
+1. Treat issue `#12` as a README clarification for the helper-backed path, not as a product behavior change.
+2. Keep the wording anchored to the already-validated issue `#11` evidence instead of speculating about other multicast environments.
+3. If review later shows the app UI itself still needs stronger wording, handle that in a separate tiny branch after this README-only slice.
 
 ## Stop / Reassess Conditions
-- If helper expectations start demanding richer orchestration than a thin script plus console commands can provide, stop and re-evaluate whether the console example should grow dedicated validation subcommands instead of turning the script into a second protocol implementation.
-- If a future live WinUI pass shows multicast ergonomics are still confusing, address that as a separate UI/docs slice rather than widening this helper branch.
+- If reviewer feedback shows the README-only note is not enough to stop confusion, stop and decide whether the next change belongs in `AppLocalizer.cs` or in a broader helper-validation guide instead of expanding this branch ad hoc.
+- If the helper branch `#10` changes its multicast contract materially before merge, re-check that this wording still matches the actual stacked base.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -155,3 +155,9 @@
 - Decision: do not widen PR `#10` into serializer-aware peer expansion. Instead, document clearly that the helper is currently for `AutoBinary` validation, and direct `RawHex` validation to the in-app mock endpoint or another RawHex-speaking peer.
 - Why: this preserves the branch's narrow scope and keeps the helper truthful without dragging a second serializer dimension into a docs/helper-only slice.
 - Consequences: the next live WinUI validation pass can still use the helper safely for `AutoBinary`, while any future need for a `RawHex` external peer becomes its own explicit follow-up rather than an accidental extension of this PR.
+
+## 2026-04-16 - Fix helper-backed multicast confusion in the README first, not in runtime or live UI copy
+- Context: issue `#11` proved the multicast helper path is correct, but one-machine loopback means the WinUI live log can show an inbound copy of the app's own outbound multicast payload. The gap was operator truthfulness in the helper-backed docs rather than a transport defect.
+- Decision: handle issue `#12` as a README-only wording change on a tiny stacked branch (`docs/issue-12-multicast-loopback-wording`) and keep `AppLocalizer.cs` / runtime behavior untouched for now.
+- Why: this is the smallest structurally correct fix. The confusion appears first in the helper usage guidance, so clarifying the README is enough to tell the truth without widening into product text churn before review asks for it.
+- Consequences: draft PR `#13` now carries only the README note and usage tip; if reviewers still want stronger wording in the live UI, that should happen in a separate follow-up branch rather than by expanding this docs slice retroactively.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,16 +1,14 @@
 # TODOS
 
 ## Execution Context
-- Active branch: `feat/issue-9-winui-transport-helper`.
-- Tracking issue: GitHub issue `#9` (`Add reusable local WinUI transport validation helper`).
-- Draft PR: `#10` (`[codex] add WinUI transport validation helper`).
-- Branch rule: keep this branch scoped to external local validation helper commands, one wrapper script, and direct README guidance only.
+- Active branch: `docs/issue-12-multicast-loopback-wording`.
+- Tracking issue: GitHub issue `#12` (`Clarify helper-backed multicast self-loopback behavior in WinUI validation docs`).
+- Draft PR: `#13` (`[codex] clarify helper multicast loopback note`), stacked on top of helper draft PR `#10`.
+- Relevant prior validation: GitHub issue `#11` proved the helper-backed multicast behavior that motivated this wording follow-up.
+- Branch rule: keep this branch scoped to the smallest truthful helper-backed multicast wording clarification only.
 
 ## Current TODOs
-- [ ] Use the new helper during one live WinUI UDP / multicast validation pass, then judge whether multicast UX wording still needs tightening.
-  Scope: `examples/CommLib.Examples.WinUI`, `scripts/Start-WinUiTransportValidation.ps1`, and any resulting README or UI-copy follow-up.
-  Objective: turn the remaining manual transport validation backlog into a repeatable real-app pass now that the helper exists. This helper is currently for the `AutoBinary` path; `RawHex` still needs a different peer.
-  Validation: run one focused live WinUI session with the helper-backed TCP/UDP/multicast path and capture any remaining operator confusion separately.
+- None on this branch. Issue `#12` is implemented and published for review as a README-only stacked PR.
 
 ## Deferred Backlog
 
@@ -63,9 +61,19 @@
 - Objective: make the multicast mock path understandable during local operator testing without overcomplicating the transport layer.
 - Relevant context: `LocalMockEndpointService` now joins the selected multicast group and replies back to the sender port so a single machine can act as both sender and mock peer; depending on socket loopback behavior, the live log may still show more than one inbound event per send.
 - Scope: `examples/CommLib.Examples.WinUI/Services/LocalMockEndpointService.cs`, `examples/CommLib.Examples.WinUI/ViewModels/MainViewModel.cs`, `examples/CommLib.Examples.WinUI/Services/AppLocalizer.cs`, and `examples/CommLib.Examples.WinUI/Views/DeviceLabView.cs`.
-- Current status: status text already warns about self traffic plus peer echo, but the UX has not been manually judged yet in the real app.
-- Known blockers/open questions: how the local NIC / multicast loopback behavior presents on this machine during a full WinUI send/receive session, and whether the current status text is enough.
-- Most natural next step: run the manual multicast mock validation from `Device Lab`, capture the exact live-log behavior, then either keep the current wording or tighten it with the smallest safe UI-only change.
+- Current status: helper-backed one-machine multicast wording now has a README clarification in draft PR `#13`, but the in-app mock status copy remains unchanged.
+- Known blockers/open questions: whether the existing in-app mock wording is already sufficient now that the helper README path is clearer.
+- Most natural next step: wait for review on PR `#13`, then revisit only if operators still misread the in-app mock path.
+
+### [P1_SOON] Decide whether helper-backed multicast wording needs to move into live UI copy after PR `#13`
+- What remains: decide whether the README clarification from issue `#12` is enough, or whether nearby UI/status wording should also mention one-machine self-loopback behavior.
+- Why deferred: issue `#12` intentionally stayed README-only to keep the follow-up as the smallest truthful change.
+- Objective: avoid widening a docs clarification into unnecessary product text churn while still leaving a clean path if reviewers/operators want the app UI itself to say more.
+- Relevant context: issue `#11` proved that helper-backed multicast is correct and that the WinUI app can log its own outbound payload as inbound traffic on one machine; draft PR `#13` now documents that behavior in the helper section of the WinUI README.
+- Scope: `examples/CommLib.Examples.WinUI/Services/AppLocalizer.cs`, possibly nearby WinUI README wording, and any tiny follow-up docs/UI branch.
+- Current status: README is updated, UI copy is unchanged.
+- Known blockers/open questions: whether the README clarification alone is enough to prevent confusion during real review/use.
+- Most natural next step: let PR `#13` review land first, then decide whether any UI text change is still justified.
 
 ### [P2_LATER] Safely map full `DeviceLabTheme` templated-control styles before broad rollout
 - What remains: decide whether to prune the currently unused templated-control style helpers in `DeviceLabTheme` or reintroduce them with verified WinUI default-style keys and a startup-safe initialization path.
@@ -108,6 +116,8 @@
 - Most natural next step: wait until the schema-backed compose/inspect layer exists and at least one real device contract pressures a broader numbering or value-type surface.
 
 ## Completed
+- [x] 2026-04-16: created GitHub issue `#11`, ran a live helper-backed WinUI UDP / multicast validation pass, and confirmed UDP roundtrip, multicast helper send/receive, and transport-panel switching on both `Device Lab` and `Settings`; the one new finding was that one-machine multicast logs a self-loopback inbound copy of the app's own outbound payload.
+- [x] 2026-04-16: created GitHub issue `#12`, added a README-only helper-backed multicast self-loopback clarification on `docs/issue-12-multicast-loopback-wording`, and opened draft PR `#13` stacked on `feat/issue-9-winui-transport-helper`; no runtime or UI behavior changed, and no build/test rerun was needed because the change is docs-only and grounded in the completed issue `#11` validation evidence.
 - [x] 2026-04-16: created GitHub issue `#9` and added a reusable local WinUI transport validation helper by introducing console-side `tcp-echo-server` / `udp-echo-server`, adding `scripts/Start-WinUiTransportValidation.ps1`, and updating the WinUI/console READMEs; verified with `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj`, helper-backed TCP/UDP smoke runs, and a helper-backed multicast send smoke.
 - [x] 2026-04-14: integrated `feat/bitfield-endianness`, `feat/bitfield-schema-log-enrichment`, and `feat/runtime-hardening-clean-base` onto `integration/main-refresh-20260414`, then replayed the 2026-04-14 gate-fix and Korean XML documentation commits on top; verified with `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`, `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`, `dotnet restore examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`, and `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj --no-restore`.
 - [x] 2026-04-14: fixed the `_deviceOperationGates` leak in `ConnectionManager` by keeping per-device operation gates reference-counted and removing them once the last lease is released for a disconnected device; added `DisconnectAsync_DistinctDevices_ReleasesUnusedDeviceGates` coverage and verified with `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`.

--- a/examples/CommLib.Examples.WinUI/README.md
+++ b/examples/CommLib.Examples.WinUI/README.md
@@ -55,6 +55,8 @@ powershell -ExecutionPolicy Bypass -File ./scripts/Start-WinUiTransportValidatio
 - If the WinUI app is set to `RawHex`, use the in-app mock endpoint or another `RawHex`-speaking peer instead of this helper.
 - `TcpEcho` and `UdpEcho` keep the external peer alive until `Ctrl+C` or an optional `-TimeoutMs` elapses.
 - `MulticastReceive` waits for one inbound frame and exits; run it before triggering a WinUI send or a helper `MulticastSend`.
+- In one-machine multicast validation with loopback enabled, the WinUI live log can also show the app's own outbound multicast payload as an `Inbound message`. That self-loopback line is expected and does not mean the helper path failed.
+- Use different message bodies for helper `MulticastSend` and the WinUI `Send` action if you want to distinguish helper traffic from the app's own looped-back multicast payload quickly.
 - `MulticastReceive` returns a non-zero exit code when the timeout elapses without traffic, so a no-message validation run is visible immediately.
 - Add `-NoBuild` if the console example is already built and you want faster repeated runs. `pwsh` works too if PowerShell 7 is installed; the examples above use Windows PowerShell syntax because it is present on more developer machines by default.
 


### PR DESCRIPTION
﻿## Summary
- clarify the helper-backed multicast README note for one-machine loopback validation
- explain that the WinUI live log can show the app's own outbound multicast payload as an inbound line when loopback is enabled
- suggest using distinct helper/app message bodies to distinguish self-loopback from helper traffic quickly

## Scope
- docs only
- no runtime or UI behavior changes

## Validation
- docs-only change
- wording is based on the completed live helper-backed multicast validation from issue #11

## Tracking
- closes #12
- stacked on top of #10 / `feat/issue-9-winui-transport-helper`
