### PR TITLE
[codex] add WinUI transport validation helper

### DIFF
--- a/examples/CommLib.Examples.Console/Program.cs
+++ b/examples/CommLib.Examples.Console/Program.cs
@@ -30,7 +30,9 @@ internal static class ExampleConsole
             return args[0].ToLowerInvariant() switch
             {
                 "tcp-demo" => await RunTcpDemoAsync(args[1..]).ConfigureAwait(false),
+                "tcp-echo-server" => await RunTcpEchoServerOnlyAsync(args[1..]).ConfigureAwait(false),
                 "udp-demo" => await RunUdpDemoAsync(args[1..]).ConfigureAwait(false),
+                "udp-echo-server" => await RunUdpEchoServerOnlyAsync(args[1..]).ConfigureAwait(false),
                 "multicast-send" => await RunMulticastSendAsync(args[1..]).ConfigureAwait(false),
                 "multicast-receive" => await RunMulticastReceiveAsync(args[1..]).ConfigureAwait(false),
                 "serial-demo" => await RunSerialDemoAsync(args[1..]).ConfigureAwait(false),
@@ -75,6 +77,76 @@ internal static class ExampleConsole
         return 0;
     }
 
+    private static async Task<int> RunTcpEchoServerOnlyAsync(string[] args)
+    {
+        var port = GetIntOption(args, "--port") ?? 7001;
+        var timeoutMs = GetIntOption(args, "--timeout-ms");
+        using var lifetime = CreatePeerLifetime(timeoutMs);
+        using var listener = new TcpListener(IPAddress.Loopback, port);
+        listener.Start();
+        var actualPort = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        Console.WriteLine($"[tcp-echo-server] listening on 127.0.0.1:{actualPort}");
+        if (timeoutMs is > 0)
+        {
+            Console.WriteLine($"[tcp-echo-server] will stop after {timeoutMs} ms if no one cancels earlier");
+        }
+        else
+        {
+            Console.WriteLine("[tcp-echo-server] press Ctrl+C to stop");
+        }
+
+        while (!lifetime.IsCancellationRequested)
+        {
+            TcpClient? client = null;
+            try
+            {
+                client = await listener.AcceptTcpClientAsync(lifetime.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (lifetime.IsCancellationRequested)
+            {
+                break;
+            }
+
+            using (client)
+            using (var stream = client.GetStream())
+            {
+                Console.WriteLine($"[tcp-echo-server] client connected from {client.Client.RemoteEndPoint}");
+
+                while (!lifetime.IsCancellationRequested)
+                {
+                    byte[] frame;
+                    try
+                    {
+                        frame = await ReadLengthPrefixedFrameAsync(stream, lifetime.Token).ConfigureAwait(false);
+                    }
+                    catch (EndOfStreamException)
+                    {
+                        Console.WriteLine("[tcp-echo-server] client disconnected");
+                        break;
+                    }
+                    catch (IOException) when (!lifetime.IsCancellationRequested)
+                    {
+                        Console.WriteLine("[tcp-echo-server] client disconnected");
+                        break;
+                    }
+                    catch (OperationCanceledException) when (lifetime.IsCancellationRequested)
+                    {
+                        break;
+                    }
+
+                    var message = DecodeFrame(frame);
+                    Console.WriteLine($"[tcp-echo-server] recv {DescribeMessage(message)}");
+                    await stream.WriteAsync(frame, lifetime.Token).ConfigureAwait(false);
+                    await stream.FlushAsync(lifetime.Token).ConfigureAwait(false);
+                    Console.WriteLine("[tcp-echo-server] echoed frame");
+                }
+            }
+        }
+
+        return 0;
+    }
+
     private static async Task<int> RunUdpDemoAsync(string[] args)
     {
         var serverPort = GetIntOption(args, "--server-port") ?? GetFreeUdpPort();
@@ -100,6 +172,44 @@ internal static class ExampleConsole
 
         await SendAndReceiveAsync(manager, profile, outboundMessage, cts.Token).ConfigureAwait(false);
         await serverTask.ConfigureAwait(false);
+        return 0;
+    }
+
+    private static async Task<int> RunUdpEchoServerOnlyAsync(string[] args)
+    {
+        var port = GetIntOption(args, "--port") ?? 7002;
+        var timeoutMs = GetIntOption(args, "--timeout-ms");
+        using var lifetime = CreatePeerLifetime(timeoutMs);
+        using var server = new UdpClient(new IPEndPoint(IPAddress.Loopback, port));
+
+        Console.WriteLine($"[udp-echo-server] listening on 127.0.0.1:{port}");
+        if (timeoutMs is > 0)
+        {
+            Console.WriteLine($"[udp-echo-server] will stop after {timeoutMs} ms if no one cancels earlier");
+        }
+        else
+        {
+            Console.WriteLine("[udp-echo-server] press Ctrl+C to stop");
+        }
+
+        while (!lifetime.IsCancellationRequested)
+        {
+            UdpReceiveResult inbound;
+            try
+            {
+                inbound = await server.ReceiveAsync(lifetime.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (lifetime.IsCancellationRequested)
+            {
+                break;
+            }
+
+            var message = DecodeFrame(inbound.Buffer);
+            Console.WriteLine($"[udp-echo-server] recv {DescribeMessage(message)} from {inbound.RemoteEndPoint}");
+            await server.SendAsync(inbound.Buffer, inbound.RemoteEndPoint, lifetime.Token).ConfigureAwait(false);
+            Console.WriteLine("[udp-echo-server] echoed datagram");
+        }
+
         return 0;
     }
 
@@ -289,6 +399,25 @@ internal static class ExampleConsole
         return Protocol.Encode(Serializer.Serialize(message));
     }
 
+    private static CancellationTokenSource CreatePeerLifetime(int? timeoutMs)
+    {
+        var lifetime = timeoutMs is > 0
+            ? new CancellationTokenSource(TimeSpan.FromMilliseconds(timeoutMs.Value))
+            : new CancellationTokenSource();
+
+        ConsoleCancelEventHandler? cancelHandler = null;
+        cancelHandler = (_, args) =>
+        {
+            args.Cancel = true;
+            lifetime.Cancel();
+            Console.CancelKeyPress -= cancelHandler;
+        };
+
+        Console.CancelKeyPress += cancelHandler;
+        lifetime.Token.Register(() => Console.CancelKeyPress -= cancelHandler);
+        return lifetime;
+    }
+
     private static IMessage DecodeFrame(ReadOnlySpan<byte> frame)
     {
         if (!Protocol.TryDecode(frame, out var payload, out var bytesConsumed) || bytesConsumed != frame.Length)
@@ -401,13 +530,16 @@ internal static class ExampleConsole
         Console.WriteLine();
         Console.WriteLine("Commands:");
         Console.WriteLine("  tcp-demo [--port 7001] [--message \"hello\"]");
+        Console.WriteLine("  tcp-echo-server [--port 7001] [--timeout-ms 30000]");
         Console.WriteLine("  udp-demo [--server-port 7002] [--client-port 7003] [--message \"hello\"]");
+        Console.WriteLine("  udp-echo-server [--port 7002] [--timeout-ms 30000]");
         Console.WriteLine("  multicast-receive [--group 239.0.0.241] [--port 7004] [--timeout-ms 10000]");
         Console.WriteLine("  multicast-send [--group 239.0.0.241] [--port 7004] [--message \"hello\"]");
         Console.WriteLine("  serial-demo --port COM3 --peer-port COM4 [--baud 115200] [--message \"hello\"]");
         Console.WriteLine();
         Console.WriteLine("Notes:");
         Console.WriteLine("  tcp-demo and udp-demo are self-contained loopback examples.");
+        Console.WriteLine("  tcp-echo-server and udp-echo-server stay alive for external WinUI/manual validation.");
         Console.WriteLine("  multicast-send and multicast-receive are intended to be run in separate terminals.");
         Console.WriteLine("  serial-demo requires a paired serial environment such as com0com or a hardware loopback pair.");
     }

--- a/examples/CommLib.Examples.Console/README.md
+++ b/examples/CommLib.Examples.Console/README.md
@@ -6,7 +6,9 @@
 
 ```powershell
 dotnet run --project examples/CommLib.Examples.Console -- tcp-demo
+dotnet run --project examples/CommLib.Examples.Console -- tcp-echo-server --port 7001
 dotnet run --project examples/CommLib.Examples.Console -- udp-demo
+dotnet run --project examples/CommLib.Examples.Console -- udp-echo-server --port 7002
 dotnet run --project examples/CommLib.Examples.Console -- multicast-receive --port 7004
 dotnet run --project examples/CommLib.Examples.Console -- multicast-send --port 7004
 dotnet run --project examples/CommLib.Examples.Console -- serial-demo --port COM3 --peer-port COM4
@@ -15,7 +17,9 @@ dotnet run --project examples/CommLib.Examples.Console -- serial-demo --port COM
 ## What Each Demo Covers
 
 - `tcp-demo`: starts a loopback TCP echo server, connects with `ConnectionManager`, sends one `MessageModel`, and receives the echoed frame back.
+- `tcp-echo-server`: keeps a loopback TCP echo peer alive so the WinUI example or another local process can connect and exchange multiple frames.
 - `udp-demo`: starts a loopback UDP echo server, sends one datagram through `UdpTransport`, and receives the echoed frame back.
+- `udp-echo-server`: keeps a loopback UDP echo peer alive so the WinUI example or another local process can exchange multiple datagrams.
 - `multicast-receive`: joins the multicast group and waits for one inbound frame.
 - `multicast-send`: opens `MulticastTransport` and publishes one frame to the multicast group.
 - `serial-demo`: requires a paired COM port setup such as `com0com` or a hardware loopback pair. The sample opens the peer port directly and the client port through `SerialTransport`.
@@ -24,5 +28,7 @@ dotnet run --project examples/CommLib.Examples.Console -- serial-demo --port COM
 
 - All demos use `LengthPrefixedProtocol` plus `NoOpSerializer` via the library factories.
 - The sample prints connection attempts through `IConnectionEventSink`, so reconnect policy behavior is visible during runs.
+- `tcp-echo-server` and `udp-echo-server` stop on `Ctrl+C` or an optional `--timeout-ms` so they are easy to reuse during WinUI manual validation.
+- `multicast-receive` exits with a timeout error when no traffic arrives before `--timeout-ms`, which makes empty validation runs obvious in scripts.
 - `serial-demo` is intentionally the only example that needs external setup because a single process cannot open both ends of the same serial port.
 - Run `multicast-receive` in one terminal first, then trigger `multicast-send` from another terminal.

--- a/examples/CommLib.Examples.WinUI/README.md
+++ b/examples/CommLib.Examples.WinUI/README.md
@@ -33,7 +33,23 @@ dotnet run --project examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.cspr
 - Multicast receive/send requires the same group and port on both sides.
 - Serial requires a real COM port, a paired virtual port, or hardware loopback wiring.
 - The `Device Lab` and `Settings` pages now show only the currently selected transport panel instead of every transport preset at once.
-- For local manual verification without external hardware, reuse `examples/CommLib.Examples.Console` for `tcp-demo`, `udp-demo`, or multicast send/receive peers in separate terminals.
+- For repeatable local manual verification without external hardware, use [scripts/Start-WinUiTransportValidation.ps1](../../scripts/Start-WinUiTransportValidation.ps1) to launch the repo-owned TCP/UDP echo peers or multicast send/receive flow instead of rediscovering console commands each session.
 - The in-app mock peer path covers TCP, UDP, and Multicast on loopback; Serial still stays external because it needs a paired COM environment.
 - The sample now defaults to `win-x64` again because the current branch state no longer reproduces the earlier local `Microsoft.UI.Xaml.dll` startup fault; `-r win-x86` remains available if you need to compare runtimes.
 - The default `appsettings.json` is copied to the output folder on build and then reused as the runtime settings file.
+
+## Local Validation Helper
+
+Use the helper from a separate terminal when you want the WinUI app to talk to an external local peer instead of the in-app mock endpoint:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File ./scripts/Start-WinUiTransportValidation.ps1 -Mode TcpEcho -Port 7001
+powershell -ExecutionPolicy Bypass -File ./scripts/Start-WinUiTransportValidation.ps1 -Mode UdpEcho -Port 7002
+powershell -ExecutionPolicy Bypass -File ./scripts/Start-WinUiTransportValidation.ps1 -Mode MulticastReceive -Group 239.0.0.241 -Port 7004 -TimeoutMs 30000
+powershell -ExecutionPolicy Bypass -File ./scripts/Start-WinUiTransportValidation.ps1 -Mode MulticastSend -Group 239.0.0.241 -Port 7004 -Message "hello from helper"
+```
+
+- `TcpEcho` and `UdpEcho` keep the external peer alive until `Ctrl+C` or an optional `-TimeoutMs` elapses.
+- `MulticastReceive` waits for one inbound frame and exits; run it before triggering a WinUI send or a helper `MulticastSend`.
+- `MulticastReceive` returns a non-zero exit code when the timeout elapses without traffic, so a no-message validation run is visible immediately.
+- Add `-NoBuild` if the console example is already built and you want faster repeated runs. `pwsh` works too if PowerShell 7 is installed; the examples above use Windows PowerShell syntax because it is present on more developer machines by default.

--- a/scripts/Start-WinUiTransportValidation.ps1
+++ b/scripts/Start-WinUiTransportValidation.ps1
@@ -1,0 +1,78 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("TcpEcho", "UdpEcho", "MulticastReceive", "MulticastSend")]
+    [string]$Mode,
+
+    [int]$Port,
+
+    [string]$Group = "239.0.0.241",
+
+    [string]$Message = "hello from WinUI validation helper",
+
+    [int]$TimeoutMs,
+
+    [switch]$NoBuild
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$consoleProject = Join-Path $repoRoot "examples\\CommLib.Examples.Console\\CommLib.Examples.Console.csproj"
+$consoleProjectDir = Split-Path -Parent $consoleProject
+
+if (-not (Test-Path $consoleProject)) {
+    throw "Console project not found: $consoleProject"
+}
+
+if ($NoBuild) {
+    $outputDll = Get-ChildItem -Path (Join-Path $consoleProjectDir "bin") -Filter "CommLib.Examples.Console.dll" -Recurse |
+        Sort-Object LastWriteTimeUtc -Descending |
+        Select-Object -First 1
+
+    if ($null -eq $outputDll) {
+        throw "No built console output found under '$consoleProjectDir\\bin'. Run the helper once without -NoBuild or build the console project first."
+    }
+
+    $arguments = @($outputDll.FullName)
+}
+else {
+    $arguments = @("run", "--project", $consoleProject)
+    $arguments += "--"
+}
+
+switch ($Mode) {
+    "TcpEcho" {
+        $resolvedPort = if ($PSBoundParameters.ContainsKey("Port")) { $Port } else { 7001 }
+        $arguments += @("tcp-echo-server", "--port", $resolvedPort)
+        if ($PSBoundParameters.ContainsKey("TimeoutMs")) {
+            $arguments += @("--timeout-ms", $TimeoutMs)
+        }
+    }
+    "UdpEcho" {
+        $resolvedPort = if ($PSBoundParameters.ContainsKey("Port")) { $Port } else { 7002 }
+        $arguments += @("udp-echo-server", "--port", $resolvedPort)
+        if ($PSBoundParameters.ContainsKey("TimeoutMs")) {
+            $arguments += @("--timeout-ms", $TimeoutMs)
+        }
+    }
+    "MulticastReceive" {
+        $resolvedPort = if ($PSBoundParameters.ContainsKey("Port")) { $Port } else { 7004 }
+        $arguments += @("multicast-receive", "--group", $Group, "--port", $resolvedPort)
+        if ($PSBoundParameters.ContainsKey("TimeoutMs")) {
+            $arguments += @("--timeout-ms", $TimeoutMs)
+        }
+    }
+    "MulticastSend" {
+        $resolvedPort = if ($PSBoundParameters.ContainsKey("Port")) { $Port } else { 7004 }
+        $arguments += @("multicast-send", "--group", $Group, "--port", $resolvedPort, "--message", $Message)
+    }
+}
+
+Write-Host "[helper] Running: dotnet $($arguments -join ' ')" -ForegroundColor Cyan
+& dotnet @arguments
+$exitCode = $LASTEXITCODE
+if ($exitCode -ne 0) {
+    exit $exitCode
+}


### PR DESCRIPTION
## What changed
- added `tcp-echo-server` and `udp-echo-server` commands to `CommLib.Examples.Console` for external local peer validation
- added `scripts/Start-WinUiTransportValidation.ps1` as the repo-owned entry point for TCP/UDP echo and multicast send/receive flows
- updated the WinUI and console READMEs so contributors can launch the helper without rediscovering old terminal commands
- fixed the helper `-NoBuild` path to reuse the latest built console DLL instead of assuming an apphost EXE exists

## Why
- issue #9 tracks the remaining need for a repeatable local validation path when the WinUI example should talk to an external peer instead of the in-app mock endpoint
- the original draft PR #10 was based on a local-only refreshed `main` and pulled in unrelated runtime / bitfield history, so this PR rebuilds the same helper scope on top of GitHub `main`

## Impact
- WinUI manual validation now has a one-command local peer workflow for TCP, UDP, and multicast
- `-NoBuild` now works for repeated helper runs after one console build
- this branch stays limited to validation-helper tooling and docs; it does not widen transport or runtime contracts

## Validation
- `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj`
- `powershell -ExecutionPolicy Bypass -File scripts/Start-WinUiTransportValidation.ps1 -Mode TcpEcho -NoBuild -TimeoutMs 200`
- `powershell -ExecutionPolicy Bypass -File scripts/Start-WinUiTransportValidation.ps1 -Mode UdpEcho -NoBuild -TimeoutMs 200`
- `powershell -ExecutionPolicy Bypass -File scripts/Start-WinUiTransportValidation.ps1 -Mode MulticastSend -NoBuild -Port 7004 -Message "helper smoke"`

Closes #9
