### PR TITLE
[codex] clarify helper multicast loopback note

### DIFF
--- a/examples/CommLib.Examples.WinUI/README.md
+++ b/examples/CommLib.Examples.WinUI/README.md
@@ -51,5 +51,7 @@ powershell -ExecutionPolicy Bypass -File ./scripts/Start-WinUiTransportValidatio
 
 - `TcpEcho` and `UdpEcho` keep the external peer alive until `Ctrl+C` or an optional `-TimeoutMs` elapses.
 - `MulticastReceive` waits for one inbound frame and exits; run it before triggering a WinUI send or a helper `MulticastSend`.
+- In one-machine multicast validation with loopback enabled, the WinUI live log can also show the app's own outbound multicast payload as an `Inbound message`. That self-loopback line is expected and does not mean the helper path failed.
+- Use different message bodies for helper `MulticastSend` and the WinUI `Send` action if you want to distinguish helper traffic from the app's own looped-back multicast payload quickly.
 - `MulticastReceive` returns a non-zero exit code when the timeout elapses without traffic, so a no-message validation run is visible immediately.
 - Add `-NoBuild` if the console example is already built and you want faster repeated runs. `pwsh` works too if PowerShell 7 is installed; the examples above use Windows PowerShell syntax because it is present on more developer machines by default.


### PR DESCRIPTION
## Summary
- clarify the helper-backed multicast README note for one-machine loopback validation
- explain that the WinUI live log can show the app's own outbound multicast payload as an inbound line when loopback is enabled
- suggest using distinct helper/app message bodies to distinguish self-loopback from helper traffic quickly

## Scope
- docs only
- no runtime or UI behavior changes
- rebuilt directly on top of current `main` after #14 merged

## Validation
- docs-only change
- wording is based on the completed live helper-backed multicast validation from issue #11

Closes #12
