### PR TITLE
[codex] cancel stale DeviceSession timeout waits

### DIFF
--- a/CHANGELOG_AGENT.md
+++ b/CHANGELOG_AGENT.md
@@ -109,3 +109,20 @@
   - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --collect:"XPlat Code Coverage"`
   - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --collect:"XPlat Code Coverage"`
   - Cobertura XML outputs generated under each test project's `TestResults/.../coverage.cobertura.xml`
+
+## 2026-04-16
+
+- Created GitHub issue `#17` to track the remaining `DeviceSession` timeout-wait cleanup as its own narrow correctness slice.
+- Started `fix/issue-17-device-session-timeout-cleanup` from the current `commlib-hub/main` so the preserved dirty worktrees and the merged helper/docs line stay isolated from this fix.
+- Narrowed the implementation to `DeviceSession` timeout cleanup only:
+  - added per-request timeout registrations via private `CancellationTokenSource` storage
+  - cancel and dispose those registrations immediately when a response completes before the timeout
+  - dispose timeout registrations after timeout expiry removes the pending request entry
+  - kept the current pending-response storage contract intact instead of widening into the reflection-removal refactor in the same branch
+- Added focused unit coverage for the new cleanup path:
+  - `TryCompleteResponse_CompletesResponse_CancelsPendingTimeoutRegistration`
+  - timeout tests now also assert that the timeout-registration map returns to zero after expiry
+- Verified the fix with:
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore --filter "FullyQualifiedName~DeviceSessionTests"`
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~ConnectionManagerTests"`

--- a/CURRENT_PLAN.md
+++ b/CURRENT_PLAN.md
@@ -1,57 +1,45 @@
 # Current Plan
 
-Date: 2026-04-03
+Date: 2026-04-16
 
 ## Goal
-Keep the WinUI example follow-up moving with the next work unit focused on validating the new in-app mock peer flow across the remaining transports now that transport-specific panels, conservative page transitions, the scrollable auto-follow live log, the live `DeviceLabTheme` hookup, and the new repo-level package management baseline are all in place.
+Deliver issue `#17` as a narrow `DeviceSession` correctness fix on top of the current `main`, keeping the branch limited to timeout-wait cleanup plus focused unit coverage.
 
 ## Confirmed Facts
-- Active branch is `feat/winui-localization-foundation`.
-- Localization foundation is implemented in the WinUI example:
-  - persisted `AppLanguageMode` in `appsettings.json`
-  - singleton `IAppLocalizer` / `AppLocalizer`
-  - localized shell/page/transport/language choices
-  - localized shell, Device Lab, and Settings page copy
-  - localized connection/session/status text on the main flow
-- `PointerWheelScrollBridge` forwards text-input mouse-wheel events back to the page `ScrollViewer` in `DeviceLabView` and `SettingsView`.
-- `AppShellView` animates `Device Lab` <-> `Settings` with a conservative opacity + horizontal slide transition while keeping the existing dual-host page structure.
-- `DeviceLabView` live log now uses a dedicated read-only multiline `TextBox` with its own scrollbars, no-wrap log lines, and end-of-document auto-follow.
-- The live-log follower now caches the inner `ScrollViewer` and explicitly drives it to `ScrollableHeight` after each text update instead of relying only on moving the text selection to the end.
-- `DeviceLabTheme` is now a live shared styling source for `AppShellView`, `DeviceLabView`, and `SettingsView` through safe brush/text/border resources.
-- `DeviceLabView` and `SettingsView` now collapse transport settings down to the currently selected transport instead of showing TCP/UDP/Multicast/Serial panels all at once.
-- `DeviceLabView` now includes a `Mock Endpoint` card backed by in-process `ILocalMockEndpointService` / `LocalMockEndpointService`.
-- Repo-level build/package configuration is now partially centralized:
-  - `Directory.Build.props` owns the shared `Nullable` and `ImplicitUsings` defaults
-  - `Directory.Packages.props` owns the package versions for WinUI/toolkit, `Microsoft.Extensions`, test packages, `coverlet.collector`, and `System.IO.Ports`
-  - project files now keep only project-specific package references without inline version numbers
-- Both test projects now reference `coverlet.collector` with `PrivateAssets=all`, and local `XPlat Code Coverage` runs generated Cobertura reports successfully.
-- The core WinUI example files now carry Korean comments around non-obvious lifecycle and control-flow areas, including DI bootstrap, shell/page transitions, wheel forwarding, live-log auto-follow, session state ownership, and local mock-peer runtime behavior.
-- The local mock peer flow currently behaves as follows:
-  - TCP starts a loopback echo listener on the selected TCP port and pins the host to `127.0.0.1`
-  - UDP starts a loopback echo listener on the selected UDP remote port and pins the remote host to `127.0.0.1`
-  - Multicast joins the selected group/port locally and replies back to the sender port for one-machine testing
-  - Serial remains external-only and surfaces as unavailable for the in-app mock flow
-- Verification completed on 2026-04-03:
-  - `dotnet build commlib-codex-full.sln`
-  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
-  - `dotnet test commlib-codex-full.sln`
-  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --collect:"XPlat Code Coverage"`
-  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --collect:"XPlat Code Coverage"`
-  - a `win-x64` UI Automation smoke that found the running window, located the mock-start button in the localized UI, confirmed the TCP-default screen hid the UDP-only `Local Port` label, invoked `Start Mock`, and completed a raw TCP echo roundtrip to `127.0.0.1:7001` with payload `mock-tcp-ping`
-  - a follow-up `win-x64` UI Automation smoke that started the local TCP mock, connected, sent 12 messages, and confirmed the live-log visible text range still reached the document end after the new explicit end-scroll logic
-- The earlier local `win-x64` startup crash still does not reproduce on the current branch state, so the sample remains on the restored `win-x64` default path.
-- Terminal-driven raw mouse-wheel injection was still not reliable enough to fully prove physical wheel behavior end-to-end, so real-pointer confirmation remains a manual follow-up rather than a closed automation item.
-- `PROGRESS.md` still rejects in-place `apply_patch` edits because of encoding corruption, but a date-based UTF-8 append path worked for the 2026-04-03 entry, so the file is usable for additive daily logs while full normalization remains deferred.
+- Active branch is `fix/issue-17-device-session-timeout-cleanup`, created from `commlib-hub/main` after the helper/docs line landed through PR `#14` and PR `#16`.
+- GitHub issue `#17` now tracks this work: `Fix stale DeviceSession timeout waits after session disposal`.
+- The helper follow-up line is complete on `main`:
+  - PR `#14` merged the reusable WinUI transport validation helper
+  - PR `#16` merged the helper-backed multicast self-loopback README clarification
+  - superseded PRs `#10`, `#13`, and `#15` are closed
+  - issues `#9` and `#12` are closed; issue `#11` still remains open only because the current PAT could not close or comment on issues
+- The still-open longer-lived review lines are unchanged:
+  - PR `#5`: runtime hardening
+  - PR `#8`: Generic Host lifecycle wiring
+  - PR `#7`: rawhex + schema-backed bitfield base
+  - PR `#6`: stacked WinUI RawHex schema-log follow-up
+- `DeviceSession` on current `main` still launches timeout waits with plain `Task.Delay(timeout)` and no cancellation path.
+- That means a successful response completion leaves the timeout task alive until the full timeout elapses, even though the pending request has already been removed.
+- This branch now implements the smallest safe fix inside `DeviceSession` only:
+  - timed requests register a private `CancellationTokenSource`
+  - response completion cancels and disposes that timeout registration immediately
+  - timeout firing disposes its registration after removing the pending entry
+  - the existing pending-response storage contract stays intact; no wider pending-entry refactor was introduced here
+- Focused validation succeeded on 2026-04-16:
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore --filter "FullyQualifiedName~DeviceSessionTests"`
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~ConnectionManagerTests"`
 
 ## Next Work Unit
-1. Manually validate the new UDP in-app mock peer flow from the running `win-x64` WinUI app.
-2. Manually validate the new Multicast in-app mock peer flow and decide whether the single-machine self-echo + peer-echo behavior needs clearer UX copy.
-3. Step through TCP / UDP / Multicast / Serial selection on both `Device Lab` and `Settings` with a real pointer session to confirm only the active transport panel remains visible.
-4. Validate with:
-   - interactive `win-x64` transport checks
-   - local UDP / Multicast loopback sends through the new mock card
-   - targeted `win-x86` spot-check only if a follow-up behavior tweak touches host/runtime-sensitive code
+1. Keep this branch scoped to the `DeviceSession` timeout cleanup, its focused tests, and continuity updates only.
+2. Publish issue `#17` as a narrow review branch/PR once the local state files are aligned.
+3. After issue `#17` is out for review, return to the next unblocked runtime backlog item on a fresh `main`-based branch rather than reusing this fix branch.
+
+## Next Slice Design
+1. Avoid widening this branch into the broader `DeviceSession` reflection cleanup; that remains a separate follow-up.
+2. Do not mix runtime-surface or hosting changes from PR `#5` / PR `#8` into this branch.
+3. Keep the proof focused on timeout-registration cleanup rather than trying to design a broader session shutdown contract in the same slice.
 
 ## Stop / Reassess Conditions
-- If single-machine multicast produces confusing duplicate inbound lines, prefer clarifying status/log copy or documenting the expected behavior before redesigning the transport path.
-- If any collapsed transport panel still appears in UI Automation or the live UI when it should be hidden, inspect the binding/converter path before widening the layout change.
+- If the timeout cleanup starts to require a broader pending-entry abstraction, stop and split that refactor into its own follow-up instead of expanding issue `#17`.
+- If local validation starts failing outside `DeviceSession` / `ConnectionManagerTests`, verify whether the branch accidentally widened past the intended timeout-only scope.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -83,3 +83,9 @@
 - Decision: add the package version once in `Directory.Packages.props`, then reference it only from `CommLib.Unit.Tests` and `CommLib.Infrastructure.Tests` with `PrivateAssets=all`.
 - Why: this matches the package's actual execution model, keeps non-test projects free of irrelevant dependencies, and still gives the repo-wide coverage behavior the user is aiming for because all executable tests now support `--collect:"XPlat Code Coverage"`.
 - Consequences: future coverage collection commands should run at the test-project or solution test layer; if new test projects are added later, they should opt into `coverlet.collector` the same way.
+
+## 2026-04-16 - Cancel `DeviceSession` timeout waits through per-request registrations instead of letting orphaned `Task.Delay` calls run to completion
+- Context: on current `main`, `DeviceSession` launched timeout work with fire-and-forget `Task.Delay(timeout)` calls. When a response completed early, the pending request entry disappeared, but the timeout task still stayed alive until the full delay elapsed.
+- Decision: keep the fix local to `DeviceSession` by tracking a private `CancellationTokenSource` per timed request. Timed requests now register that token source on send, response completion cancels and disposes it immediately, and the timeout path disposes it after removing the pending request.
+- Why: this is the smallest structurally correct fix for issue `#17`; it stops stale timeout waits without widening the branch into the separate reflection-removal refactor or a larger session shutdown redesign.
+- Consequences: successful responses no longer leave unnecessary timeout waits alive, focused tests can assert that timeout registrations return to zero, and any broader pending-entry abstraction can remain a later dedicated follow-up.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,52 +1,83 @@
 # TODOS
 
+## Execution Context
+- Active branch: `fix/issue-17-device-session-timeout-cleanup`
+- Tracking issue: GitHub issue `#17` (`Fix stale DeviceSession timeout waits after session disposal`)
+- Parent baseline: current `commlib-hub/main` after helper/docs merges `#14` and `#16`
+- Branch rule: keep this branch limited to `DeviceSession` timeout-wait cleanup, focused tests, and continuity updates
+
 ## Current TODOs
-- [ ] Manually validate the new UDP in-app mock peer flow from the current `win-x64` WinUI app.
-- [ ] Manually validate the new Multicast in-app mock peer flow and decide whether the single-machine self-echo + peer-echo behavior needs clearer UX copy.
-- [ ] Step through TCP / UDP / Multicast / Serial selection on both `Device Lab` and `Settings` with a real pointer session and confirm only the selected transport panel stays visible.
-- [ ] Re-check transition feel, wheel-scroll behavior, and live-log manual scrolling only if the transport-panel/manual mock pass exposes a concrete regression.
+- [ ] Publish issue `#17` as a narrow review branch once the local timeout-cleanup fix and continuity updates are committed.
+  Scope: `src/CommLib.Application/Sessions/DeviceSession.cs`, `tests/CommLib.Unit.Tests/DeviceSessionTests.cs`, and the root continuity files.
+  Validation: keep the existing local proof (`DeviceSessionTests`, `CommLib.Unit.Tests`, focused `ConnectionManagerTests`) attached to the PR body.
 
 ## Deferred Backlog
 
-### [P1_SOON] Clarify single-machine multicast mock UX if duplicate inbound lines feel confusing
-- What remains: decide whether the new in-app multicast mock flow needs stronger status/log copy, a dedicated note in the UI, or a small behavior tweak for one-machine validation sessions.
-- Why deferred: the implementation is in place and TCP has been smoke-validated, but the remaining manual multicast pass has not yet confirmed whether seeing both self loopback traffic and peer echo is intuitive enough.
-- Objective: make the multicast mock path understandable during local operator testing without overcomplicating the transport layer.
-- Relevant context: `LocalMockEndpointService` now joins the selected multicast group and replies back to the sender port so a single machine can act as both sender and mock peer; depending on socket loopback behavior, the live log may still show more than one inbound event per send.
-- Scope: `examples/CommLib.Examples.WinUI/Services/LocalMockEndpointService.cs`, `examples/CommLib.Examples.WinUI/ViewModels/MainViewModel.cs`, `examples/CommLib.Examples.WinUI/Services/AppLocalizer.cs`, and `examples/CommLib.Examples.WinUI/Views/DeviceLabView.cs`.
-- Current status: status text already warns about self traffic plus peer echo, but the UX has not been manually judged yet in the real app.
-- Known blockers/open questions: how the local NIC / multicast loopback behavior presents on this machine during a full WinUI send/receive session, and whether the current status text is enough.
-- Most natural next step: run the manual multicast mock validation from `Device Lab`, capture the exact live-log behavior, then either keep the current wording or tighten it with the smallest safe UI-only change.
+### Runtime Hardening & Correctness
+### [P1_SOON] Replace reflection-based `TrySetResponseResult` in `DeviceSession`
+- What remains: remove the runtime `GetMethod(...).Invoke(...)` path from `TrySetResponseResult()` by introducing a typed pending-entry abstraction or another non-reflection completion path.
+- Why deferred: issue `#17` intentionally stayed narrow and fixed only timeout-wait cleanup.
+- Objective: eliminate reflection from the hot response-completion path without widening this branch.
+- Relevant context: current `main` still stores pending response completions as `object` in `_pendingResponses`, and the non-generic response completion path uses reflection to finish typed `TaskCompletionSource<TResponse>` instances.
+- Scope: `src/CommLib.Application/Sessions/DeviceSession.cs`, focused unit tests, and any internal helper abstraction that replaces the reflection path.
+- Current status: reflection is still live on the non-generic path; timeout waits are now cleaned up separately on this branch.
+- Known blockers/open questions: whether the replacement should stay as a private nested helper in `DeviceSession` or become a reusable application-layer abstraction.
+- Most natural next step: design a private typed pending-entry wrapper and verify it with the existing `DeviceSessionTests` surface.
 
-### [P2_LATER] Safely map full `DeviceLabTheme` templated-control styles before broad rollout
-- What remains: decide whether to prune the currently unused templated-control style helpers in `DeviceLabTheme` or reintroduce them with verified WinUI default-style keys and a startup-safe initialization path.
-- Why deferred: during this session, a broader theme rollout exposed startup failures when the theme dictionary eagerly created styles that depended on missing default resource keys such as `DefaultListViewStyle`.
-- Objective: either make the full theme surface safe and real for templated controls, or remove the dormant pieces so the theme stays aligned with the actual UI contract.
-- Relevant context: the current successful hookup uses `DeviceLabTheme.Shared` for live brush/text/border resources in `AppShellView`, `DeviceLabView`, and `SettingsView`; broad app-resource merging and eager templated-control style creation proved too risky for the current step.
-- Scope: `examples/CommLib.Examples.WinUI/Styles/DeviceLabTheme.cs` plus any future consumer updates in the WinUI views.
-- Current status: the app now runs successfully with the safe subset, but keys/methods for broader control styles still exist as future design-space rather than live behavior.
-- Known blockers/open questions: which default WinUI style keys are actually available in this app/runtime combination, and whether a code-built WinUI example should keep those style definitions at all.
-- Most natural next step: inventory the actual default style keys available at runtime, then either delete the dormant helpers or add back only the verified ones behind a small focused validation pass.
+### Production Integration & Hosting
+### [P1_SOON] Expose `IConnectionEventSink` through DI without coupling callers to `ConnectionManager` internals
+- What remains: give `AddCommLibCore()` a DI-friendly way to accept an `IConnectionEventSink` implementation.
+- Why deferred: this is a runtime-surface change and should not be mixed into issue `#17`.
+- Objective: let production callers wire logging and metrics without reflection or internal constructor knowledge.
+- Relevant context: `ConnectionManager` already accepts an optional `IConnectionEventSink`, but the hosting layer still does not surface it.
+- Scope: `src/CommLib.Hosting`, `src/CommLib.Infrastructure/Sessions`, and any resulting interface-boundary adjustment.
+- Current status: still deferred outside this timeout-only branch.
+- Known blockers/open questions: whether the sink should stay in infrastructure or move upward so hosting can reference it more cleanly.
+- Most natural next step: revisit this after the current timeout fix is out for review.
 
-### [P2_LATER] Add a reusable local WinUI transport validation helper
-- What remains: package the local TCP/UDP echo peer and multicast verification flow into a repo-owned helper script or documented workflow tailored for the WinUI example.
-- Why deferred: the existing console example plus ad-hoc local echo commands are enough for immediate manual verification, but the setup is still more manual than it should be.
-- Objective: make WinUI transport validation repeatable without rediscovering local peer commands every session.
-- Relevant context: `examples/CommLib.Examples.Console` already provides `tcp-demo`, `udp-demo`, `multicast-send`, and `multicast-receive`; during this session we also used local TCP/UDP echo peers to support WinUI manual checks.
-- Scope: likely `examples/CommLib.Examples.Console`, WinUI README/docs, and possibly a small helper script under `scripts/` or `examples/`.
-- Current status: no dedicated helper exists yet; validation instructions are partly in chat and partly in example READMEs.
-- Known blockers/open questions: whether the best shape is a PowerShell script, extra console subcommands, or documentation-only guidance.
-- Most natural next step: after the current interactive validation pass, capture the exact repeatable commands that felt necessary and package only that minimal workflow.
+### API / Contract Truthfulness
+### [P1_SOON] Decide whether `ReconnectOptions` naming is still too broad for connect-time retry only
+- What remains: choose between doc-only clarification, a staged alias/deprecation path, or a later breaking rename.
+- Why deferred: the current behavior is explicit, but issue `#17` is a narrower correctness fix and should not widen into public contract churn.
+- Objective: keep the public configuration surface truthful without unnecessary compatibility churn.
+- Relevant context: the runtime still treats post-connect receive failure as terminal and `ReconnectOptions` still affects connect-time transport-open retry only.
+- Scope: `src/CommLib.Domain/Configuration/ReconnectOptions.cs`, `DeviceProfile`, docs, and any compatibility shim if a staged alias is chosen.
+- Current status: still pending on a separate branch/PR.
+- Known blockers/open questions: how much external dependency exists on the current property/type names.
+- Most natural next step: inventory references before changing names.
 
+### Review & Delivery
+### [P1_SOON] Resolve the longer-lived open review lines on top of current `main`
+- What remains: review and merge or replace the still-open PRs `#5`, `#8`, `#7`, and `#6`.
+- Why deferred: issue `#17` is a small correctness fix that should stay publishable on its own.
+- Objective: reduce the amount of long-lived branch state that is still open after the helper/docs line landed.
+- Relevant context: `#14` and `#16` are now merged; the remaining open lines are older runtime/hosting/rawhex branches.
+- Scope: GitHub PR management plus any minimal rebasing/replacement work needed per line.
+- Current status: all four PRs remain open at the time this branch was created.
+- Known blockers/open questions: whether each line is still reviewable as-is against current `main` or now needs a clean replacement branch.
+- Most natural next step: once issue `#17` is out, re-evaluate PR `#8` and PR `#5` first because they are the next runtime-facing lines.
+
+### Repo Hygiene
 ### [P2_LATER] Normalize `PROGRESS.md` encoding for safe future updates
-- What remains: identify the current mixed/non-UTF-8 encoding issue in `PROGRESS.md` and convert it to a stable encoding without losing prior history.
-- Why deferred: this does not block the product work itself, and a careless rewrite could damage an important project memory file.
-- Objective: make future automated updates to `PROGRESS.md` safe and tool-friendly.
-- Relevant context: `apply_patch` rejected an in-place `PROGRESS.md` update on 2026-04-03 because the file stream was not valid UTF-8; we were still able to append the `2026-04-03` daily log as new UTF-8 text without rewriting older bytes.
+- What remains: rewrite `PROGRESS.md` into a stable UTF-8 form without losing history.
+- Why deferred: it is orthogonal to issue `#17`, and a careless rewrite could damage project memory.
+- Objective: make future progress updates safe for normal in-place editing.
+- Relevant context: `apply_patch` still rejects in-place edits on some worktrees because `PROGRESS.md` contains non-UTF-8 or mixed-encoding content.
 - Scope: `PROGRESS.md` only.
-- Current status: append-only daily logging is workable, but some older/later sections still show encoding corruption depending on the reader and the file is not safe for normal in-place patching.
-- Known blockers/open questions: whether the file contains mixed UTF-8 and legacy code-page bytes, and what normalization path preserves the current readable Korean content best.
-- Most natural next step: back up the file, detect the dominant encoding per corrupted section, and rewrite once with a verified UTF-8 result so future updates can use normal in-place editing again.
+- Current status: still deferred.
+- Known blockers/open questions: the precise legacy encoding mix and the safest normalization path.
+- Most natural next step: back up the file and normalize it in one deliberate hygiene-focused branch.
+
+### GitHub Hygiene
+### [P3_NICE] Close stale issue `#11` once GitHub permissions allow it
+- What remains: close GitHub issue `#11`, which describes the already-completed helper-backed WinUI validation pass.
+- Why deferred: the current PAT could not close or comment on issues even though PR merge operations succeeded.
+- Objective: keep the repo issue list aligned with actual completed work.
+- Relevant context: issue `#11` is the only remaining open issue after issues `#9` and `#12` were auto-closed by merged PRs.
+- Scope: GitHub issue state only.
+- Current status: still open because of PAT permission limits, not because validation remains incomplete.
+- Known blockers/open questions: whether the token permissions will be widened or whether this must be closed manually in the browser.
+- Most natural next step: close it manually or with a higher-permission token the next time GitHub hygiene is touched.
 
 ## Completed
 - [x] 2026-04-03: added `coverlet.collector` to both test projects through `Directory.Packages.props` and verified `XPlat Code Coverage` output generation for unit and infrastructure tests.

--- a/src/CommLib.Application/Sessions/DeviceSession.cs
+++ b/src/CommLib.Application/Sessions/DeviceSession.cs
@@ -13,6 +13,7 @@ public sealed class DeviceSession : IDeviceSession
     private readonly Channel<IMessage> _outbound = Channel.CreateBounded<IMessage>(64);
     private readonly PendingRequestStore _pendingRequestStore = new();
     private readonly Dictionary<Guid, object> _pendingResponses = new();
+    private readonly Dictionary<Guid, CancellationTokenSource> _pendingResponseTimeouts = new();
     private readonly object _syncRoot = new();
     private readonly int _maxPendingRequests;
     private readonly TimeSpan? _defaultResponseTimeout;
@@ -112,6 +113,7 @@ public sealed class DeviceSession : IDeviceSession
         where TResponse : IResponseMessage
     {
         TaskCompletionSource<TResponse>? responseTcs;
+        CancellationTokenSource? timeoutRegistration;
 
         lock (_syncRoot)
         {
@@ -124,8 +126,10 @@ public sealed class DeviceSession : IDeviceSession
             _pendingResponses.Remove(response.CorrelationId);
             _pendingRequestStore.Complete(response.CorrelationId);
             responseTcs = typedPending;
+            timeoutRegistration = DetachPendingTimeoutRegistration(response.CorrelationId);
         }
 
+        CancelAndDisposeTimeoutRegistration(timeoutRegistration);
         responseTcs.TrySetResult(response);
         return true;
     }
@@ -137,22 +141,27 @@ public sealed class DeviceSession : IDeviceSession
     /// <returns>대기 중인 요청을 찾아 완료했으면 <see langword="true"/>이고, 아니면 <see langword="false"/>입니다.</returns>
     public bool TryCompleteResponse(IResponseMessage response)
     {
+        object? pending;
+        CancellationTokenSource? timeoutRegistration;
+
         lock (_syncRoot)
         {
-            if (!_pendingResponses.TryGetValue(response.CorrelationId, out var pending))
+            if (!_pendingResponses.TryGetValue(response.CorrelationId, out pending))
             {
                 return false;
             }
 
             _pendingResponses.Remove(response.CorrelationId);
             _pendingRequestStore.Complete(response.CorrelationId);
-
-            return pending switch
-            {
-                TaskCompletionSource<IResponseMessage> typed => typed.TrySetResult(response),
-                _ => TrySetResponseResult(pending, response)
-            };
+            timeoutRegistration = DetachPendingTimeoutRegistration(response.CorrelationId);
         }
+
+        CancelAndDisposeTimeoutRegistration(timeoutRegistration);
+        return pending switch
+        {
+            TaskCompletionSource<IResponseMessage> typed => typed.TrySetResult(response),
+            _ => TrySetResponseResult(pending, response)
+        };
     }
 
     private Task SendRequest<TRequest, TResponse>(
@@ -162,10 +171,19 @@ public sealed class DeviceSession : IDeviceSession
         where TRequest : IRequestMessage
         where TResponse : IResponseMessage
     {
+        var responseTimeout = timeout ?? _defaultResponseTimeout;
+        CancellationTokenSource? timeoutRegistration = null;
+
+        if (responseTimeout is { } effectiveTimeout && effectiveTimeout > TimeSpan.Zero)
+        {
+            timeoutRegistration = new CancellationTokenSource();
+        }
+
         lock (_syncRoot)
         {
             if (_pendingResponses.Count >= _maxPendingRequests)
             {
+                timeoutRegistration?.Dispose();
                 var exception = new InvalidOperationException("Pending request limit has been reached.");
                 responseTcs.TrySetException(exception);
                 return Task.FromException(exception);
@@ -173,6 +191,7 @@ public sealed class DeviceSession : IDeviceSession
 
             if (!_outbound.Writer.TryWrite(request))
             {
+                timeoutRegistration?.Dispose();
                 var exception = new InvalidOperationException("Outbound queue is full.");
                 responseTcs.TrySetException(exception);
                 return Task.FromException(exception);
@@ -180,12 +199,16 @@ public sealed class DeviceSession : IDeviceSession
 
             _pendingResponses[request.CorrelationId] = responseTcs;
             _pendingRequestStore.Register(request.CorrelationId);
+
+            if (timeoutRegistration is not null)
+            {
+                _pendingResponseTimeouts[request.CorrelationId] = timeoutRegistration;
+            }
         }
 
-        var responseTimeout = timeout ?? _defaultResponseTimeout;
-        if (responseTimeout is { } effectiveTimeout && effectiveTimeout > TimeSpan.Zero)
+        if (responseTimeout is { } effectiveResponseTimeout && effectiveResponseTimeout > TimeSpan.Zero && timeoutRegistration is not null)
         {
-            _ = HandleTimeoutAsync(request.CorrelationId, effectiveTimeout, responseTcs);
+            _ = HandleTimeoutAsync(request.CorrelationId, effectiveResponseTimeout, responseTcs, timeoutRegistration.Token);
         }
 
         return Task.CompletedTask;
@@ -194,10 +217,20 @@ public sealed class DeviceSession : IDeviceSession
     private async Task HandleTimeoutAsync<TResponse>(
         Guid correlationId,
         TimeSpan timeout,
-        TaskCompletionSource<TResponse> responseTcs)
+        TaskCompletionSource<TResponse> responseTcs,
+        CancellationToken cancellationToken)
         where TResponse : IResponseMessage
     {
-        await Task.Delay(timeout).ConfigureAwait(false);
+        try
+        {
+            await Task.Delay(timeout, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        CancellationTokenSource? timeoutRegistration;
 
         lock (_syncRoot)
         {
@@ -207,9 +240,37 @@ public sealed class DeviceSession : IDeviceSession
             }
 
             _pendingRequestStore.Complete(correlationId);
+            timeoutRegistration = DetachPendingTimeoutRegistration(correlationId);
         }
 
+        DisposeTimeoutRegistration(timeoutRegistration);
         responseTcs.TrySetException(new TimeoutException($"Timed out waiting for response to correlation '{correlationId}'."));
+    }
+
+    private CancellationTokenSource? DetachPendingTimeoutRegistration(Guid correlationId)
+    {
+        if (_pendingResponseTimeouts.Remove(correlationId, out var timeoutRegistration))
+        {
+            return timeoutRegistration;
+        }
+
+        return null;
+    }
+
+    private static void CancelAndDisposeTimeoutRegistration(CancellationTokenSource? timeoutRegistration)
+    {
+        if (timeoutRegistration is null)
+        {
+            return;
+        }
+
+        timeoutRegistration.Cancel();
+        timeoutRegistration.Dispose();
+    }
+
+    private static void DisposeTimeoutRegistration(CancellationTokenSource? timeoutRegistration)
+    {
+        timeoutRegistration?.Dispose();
     }
 
     private static bool TrySetResponseResult(object pending, IResponseMessage response)

--- a/tests/CommLib.Unit.Tests/DeviceSessionTests.cs
+++ b/tests/CommLib.Unit.Tests/DeviceSessionTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using CommLib.Application.Sessions;
 using CommLib.Domain.Messaging;
 using Xunit;
@@ -112,6 +113,28 @@ public sealed class DeviceSessionTests
     }
 
     /// <summary>
+    /// 응답이 먼저 완료되면 대기 중인 timeout 등록도 즉시 취소되고 정리되는지 확인합니다.
+    /// </summary>
+    [Fact]
+    public async Task TryCompleteResponse_CompletesResponse_CancelsPendingTimeoutRegistration()
+    {
+        var session = new DeviceSession("device-1");
+        var request = new FakeRequestMessage(12);
+        var result = session.Send<FakeRequestMessage, FakeResponseMessage>(request, TimeSpan.FromSeconds(5));
+        var response = new FakeResponseMessage(13) { CorrelationId = request.CorrelationId };
+
+        Assert.Equal(1, GetPendingTimeoutRegistrationCount(session));
+
+        var completed = session.TryCompleteResponse(response);
+        var completedResponse = await result.ResponseTask;
+
+        Assert.True(completed);
+        Assert.Same(response, completedResponse);
+        Assert.Equal(0, session.PendingRequestCount);
+        Assert.Equal(0, GetPendingTimeoutRegistrationCount(session));
+    }
+
+    /// <summary>
     /// 알 수 없는 상관관계 응답은 완료 처리하지 않고 무시하는지 확인합니다.
     /// </summary>
     [Fact]
@@ -140,6 +163,7 @@ public sealed class DeviceSessionTests
 
         Assert.Contains("Timed out waiting for response", exception.Message);
         Assert.Equal(0, session.PendingRequestCount);
+        Assert.Equal(0, GetPendingTimeoutRegistrationCount(session));
     }
 
     /// <summary>
@@ -273,5 +297,14 @@ public sealed class DeviceSessionTests
     {
         Assert.True(session.TryDequeueOutbound(out var message));
         return Assert.IsAssignableFrom<IMessage>(message);
+    }
+
+    private static int GetPendingTimeoutRegistrationCount(DeviceSession session)
+    {
+        var field = typeof(DeviceSession).GetField("_pendingResponseTimeouts", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+
+        var registrations = Assert.IsType<Dictionary<Guid, CancellationTokenSource>>(field.GetValue(session));
+        return registrations.Count;
     }
 }


### PR DESCRIPTION
## What changed
- replaced the fire-and-forget `Task.Delay(timeout)` path in `DeviceSession` with per-request timeout registrations backed by `CancellationTokenSource`
- cancel and dispose timeout registrations immediately when a response completes before the timeout elapses
- dispose timeout registrations after timeout expiry removes the pending request entry
- added focused `DeviceSessionTests` coverage for timeout-registration cleanup on both early response completion and real timeout expiry
- refreshed the root continuity files so this branch records issue `#17` as the active narrow work unit

## Why
- issue #17 tracks the remaining `DeviceSession` timeout cleanup gap on current `main`
- the previous implementation left timeout waits alive until the full delay elapsed even after a response had already completed and removed the pending request entry
- this PR fixes that specific cleanup problem without widening into the separate reflection-removal refactor or broader runtime-surface work

## Impact
- successful responses no longer leave unnecessary timeout waits alive inside `DeviceSession`
- timed-out requests still fail the response task the same way, but their timeout registrations now clean up deterministically
- the branch stays limited to `DeviceSession` correctness plus focused tests

## Validation
- `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore --filter "FullyQualifiedName~DeviceSessionTests"`
- `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
- `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~ConnectionManagerTests"`

Closes #17
