### PR TITLE
[codex] wire Generic Host lifecycle into AddCommLibCore

### DIFF
--- a/CHANGELOG_AGENT.md
+++ b/CHANGELOG_AGENT.md
@@ -126,3 +126,15 @@
   - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore --filter "FullyQualifiedName~DeviceSessionTests"`
   - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
   - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~ConnectionManagerTests"`
+- Started `feat/hosting-lifecycle-wiring-main-base` from the current `commlib-hub/main` after PR `#18` so the Generic Host lifecycle line could be rebuilt without the stale branch drift in PR `#8`.
+- Rebuilt the hosting-lifecycle slice on that clean base:
+  - added `AddCommLibCore(this IServiceCollection, IConfiguration)` to bind `CommLibOptions`
+  - added `CommLibHostedService` to start enabled configured devices through `DeviceBootstrapper`
+  - disposed `IConnectionManager` on host stop
+  - added `InternalsVisibleTo("CommLib.Unit.Tests")` plus focused `CommLibHostedServiceTests`
+  - added only the package/project references needed for the hosting test path
+- Verified the clean hosting replacement with:
+  - `dotnet restore tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj`
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore --filter "FullyQualifiedName~CommLibHostedServiceTests"`
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`

--- a/CURRENT_PLAN.md
+++ b/CURRENT_PLAN.md
@@ -3,43 +3,38 @@
 Date: 2026-04-16
 
 ## Goal
-Deliver issue `#17` as a narrow `DeviceSession` correctness fix on top of the current `main`, keeping the branch limited to timeout-wait cleanup plus focused unit coverage.
+Deliver a clean replacement for stale PR `#8` on top of the current `main`, limited to configuration-bound `AddCommLibCore(...)` registration plus Generic Host lifecycle wiring.
 
 ## Confirmed Facts
-- Active branch is `fix/issue-17-device-session-timeout-cleanup`, created from `commlib-hub/main` after the helper/docs line landed through PR `#14` and PR `#16`.
-- GitHub issue `#17` now tracks this work: `Fix stale DeviceSession timeout waits after session disposal`.
-- The helper follow-up line is complete on `main`:
-  - PR `#14` merged the reusable WinUI transport validation helper
-  - PR `#16` merged the helper-backed multicast self-loopback README clarification
-  - superseded PRs `#10`, `#13`, and `#15` are closed
-  - issues `#9` and `#12` are closed; issue `#11` still remains open only because the current PAT could not close or comment on issues
-- The still-open longer-lived review lines are unchanged:
-  - PR `#5`: runtime hardening
-  - PR `#8`: Generic Host lifecycle wiring
-  - PR `#7`: rawhex + schema-backed bitfield base
-  - PR `#6`: stacked WinUI RawHex schema-log follow-up
-- `DeviceSession` on current `main` still launches timeout waits with plain `Task.Delay(timeout)` and no cancellation path.
-- That means a successful response completion leaves the timeout task alive until the full timeout elapses, even though the pending request has already been removed.
-- This branch now implements the smallest safe fix inside `DeviceSession` only:
-  - timed requests register a private `CancellationTokenSource`
-  - response completion cancels and disposes that timeout registration immediately
-  - timeout firing disposes its registration after removing the pending entry
-  - the existing pending-response storage contract stays intact; no wider pending-entry refactor was introduced here
-- Focused validation succeeded on 2026-04-16:
-  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore --filter "FullyQualifiedName~DeviceSessionTests"`
+- Active branch is `feat/hosting-lifecycle-wiring-main-base`, created from the current `commlib-hub/main` after PR `#18` merged the `DeviceSession` timeout cleanup.
+- The older PR `#8` is no longer a safe merge candidate:
+  - GitHub reports it as not mergeable against current `main`
+  - its diff has widened far past hosting lifecycle wiring and now includes many unrelated files
+- The clean replacement on this branch intentionally keeps only the hosting-lifecycle slice:
+  - `AddCommLibCore(this IServiceCollection, IConfiguration)` binds `CommLibOptions`
+  - `CommLibHostedService` starts enabled configured device profiles through `DeviceBootstrapper`
+  - `CommLibHostedService` disposes the connection manager on host stop
+  - focused unit coverage exercises the hosted service and configuration registration path
+- This branch does **not** pull in the not-yet-merged runtime-surface pieces from PR `#5`:
+  - no `CommLibRuntimeOptions`
+  - no inbound queue-capacity wiring
+  - no broader diagnostics or `IConnectionEventSink` surface work
+- Validation succeeded on 2026-04-16:
+  - `dotnet restore tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj`
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore --filter "FullyQualifiedName~CommLibHostedServiceTests"`
   - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
-  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~ConnectionManagerTests"`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
 
 ## Next Work Unit
-1. Keep this branch scoped to the `DeviceSession` timeout cleanup, its focused tests, and continuity updates only.
-2. Publish issue `#17` as a narrow review branch/PR once the local state files are aligned.
-3. After issue `#17` is out for review, return to the next unblocked runtime backlog item on a fresh `main`-based branch rather than reusing this fix branch.
+1. Commit the hosting-lifecycle code/test slice separately from the continuity-file updates.
+2. Publish this branch as the clean replacement for PR `#8`.
+3. Close or supersede the stale PR `#8`, then move to the next runtime-facing open line on a fresh branch.
 
 ## Next Slice Design
-1. Avoid widening this branch into the broader `DeviceSession` reflection cleanup; that remains a separate follow-up.
-2. Do not mix runtime-surface or hosting changes from PR `#5` / PR `#8` into this branch.
-3. Keep the proof focused on timeout-registration cleanup rather than trying to design a broader session shutdown contract in the same slice.
+1. Keep this branch limited to hosting registration, hosted-service lifecycle hookup, and the tests required to prove that path.
+2. Do not widen into runtime-hardening work from PR `#5`, especially queue-capacity, reconnect, or observability surface changes.
+3. Treat any follow-up around `IConnectionEventSink`, health checks, or richer host options as separate backlog items after this replacement is published.
 
 ## Stop / Reassess Conditions
-- If the timeout cleanup starts to require a broader pending-entry abstraction, stop and split that refactor into its own follow-up instead of expanding issue `#17`.
-- If local validation starts failing outside `DeviceSession` / `ConnectionManagerTests`, verify whether the branch accidentally widened past the intended timeout-only scope.
+- If the clean replacement starts needing `CommLibRuntimeOptions` or other PR `#5` dependencies to stay coherent, stop and split the lines instead of re-coupling them.
+- If validation starts failing outside the hosting/unit surface, verify whether the branch accidentally picked up unrelated changes.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -89,3 +89,9 @@
 - Decision: keep the fix local to `DeviceSession` by tracking a private `CancellationTokenSource` per timed request. Timed requests now register that token source on send, response completion cancels and disposes it immediately, and the timeout path disposes it after removing the pending request.
 - Why: this is the smallest structurally correct fix for issue `#17`; it stops stale timeout waits without widening the branch into the separate reflection-removal refactor or a larger session shutdown redesign.
 - Consequences: successful responses no longer leave unnecessary timeout waits alive, focused tests can assert that timeout registrations return to zero, and any broader pending-entry abstraction can remain a later dedicated follow-up.
+
+## 2026-04-16 - Rebuild stale PR `#8` as a clean `main`-based hosting slice without pulling runtime-hardening dependencies forward
+- Context: the older Generic Host lifecycle PR `#8` is no longer mergeable against current `main` and its diff has widened into many unrelated files. The earlier implementation also depended on runtime-hardening pieces that still live in the separate stale PR `#5`.
+- Decision: rebuild PR `#8` on a fresh `main` base with only the configuration-bound hosting surface: `AddCommLibCore(IServiceCollection, IConfiguration)`, `CommLibHostedService`, and focused tests. Do not reintroduce `CommLibRuntimeOptions`, inbound queue-capacity wiring, or broader observability surface work into this branch.
+- Why: this keeps the hosting line reviewable and publishable on its own, reduces long-lived branch drift, and avoids re-coupling two stale PR lines that should stay independently reviewable.
+- Consequences: Generic Host start/stop wiring can land first as a narrow improvement, while `IConnectionEventSink`, diagnostics, health, TLS, and other runtime-surface work remain explicit follow-up backlog items.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,9 +6,11 @@
   <ItemGroup>
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260209005" />
     <PackageVersion Include="System.IO.Ports" Version="8.0.0" />

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,15 +1,15 @@
 # TODOS
 
 ## Execution Context
-- Active branch: `fix/issue-17-device-session-timeout-cleanup`
-- Tracking issue: GitHub issue `#17` (`Fix stale DeviceSession timeout waits after session disposal`)
-- Parent baseline: current `commlib-hub/main` after helper/docs merges `#14` and `#16`
-- Branch rule: keep this branch limited to `DeviceSession` timeout-wait cleanup, focused tests, and continuity updates
+- Active branch: `feat/hosting-lifecycle-wiring-main-base`
+- Tracking line: clean replacement for stale PR `#8` (`[codex] wire Generic Host lifecycle into AddCommLibCore`)
+- Parent baseline: current `commlib-hub/main` after PR `#18` merged the `DeviceSession` timeout cleanup
+- Branch rule: keep this branch limited to configuration-bound host wiring, `CommLibHostedService`, focused unit tests, and continuity updates
 
 ## Current TODOs
-- [ ] Publish issue `#17` as a narrow review branch once the local timeout-cleanup fix and continuity updates are committed.
-  Scope: `src/CommLib.Application/Sessions/DeviceSession.cs`, `tests/CommLib.Unit.Tests/DeviceSessionTests.cs`, and the root continuity files.
-  Validation: keep the existing local proof (`DeviceSessionTests`, `CommLib.Unit.Tests`, focused `ConnectionManagerTests`) attached to the PR body.
+- [ ] Publish the clean replacement for PR `#8` once the hosting-lifecycle slice and continuity updates are committed.
+  Scope: `src/CommLib.Hosting`, `tests/CommLib.Unit.Tests/CommLibHostedServiceTests.cs`, package/project references, and the root continuity files.
+  Validation: attach the successful `restore`, focused hosted-service tests, full `CommLib.Unit.Tests`, and `CommLib.Infrastructure.Tests` runs to the replacement PR.
 
 ## Deferred Backlog
 
@@ -27,13 +27,13 @@
 ### Production Integration & Hosting
 ### [P1_SOON] Expose `IConnectionEventSink` through DI without coupling callers to `ConnectionManager` internals
 - What remains: give `AddCommLibCore()` a DI-friendly way to accept an `IConnectionEventSink` implementation.
-- Why deferred: this is a runtime-surface change and should not be mixed into issue `#17`.
+- Why deferred: the clean PR `#8` replacement intentionally stays at Generic Host start/stop wiring only.
 - Objective: let production callers wire logging and metrics without reflection or internal constructor knowledge.
-- Relevant context: `ConnectionManager` already accepts an optional `IConnectionEventSink`, but the hosting layer still does not surface it.
+- Relevant context: `ConnectionManager` already accepts an optional `IConnectionEventSink`, but the hosting layer still does not surface it even after this hosted-service branch.
 - Scope: `src/CommLib.Hosting`, `src/CommLib.Infrastructure/Sessions`, and any resulting interface-boundary adjustment.
-- Current status: still deferred outside this timeout-only branch.
+- Current status: still deferred outside this clean hosting-lifecycle branch.
 - Known blockers/open questions: whether the sink should stay in infrastructure or move upward so hosting can reference it more cleanly.
-- Most natural next step: revisit this after the current timeout fix is out for review.
+- Most natural next step: revisit this after the replacement PR for `#8` is published and the hosting layer is back on a clean base.
 
 ### API / Contract Truthfulness
 ### [P1_SOON] Decide whether `ReconnectOptions` naming is still too broad for connect-time retry only
@@ -48,14 +48,14 @@
 
 ### Review & Delivery
 ### [P1_SOON] Resolve the longer-lived open review lines on top of current `main`
-- What remains: review and merge or replace the still-open PRs `#5`, `#8`, `#7`, and `#6`.
-- Why deferred: issue `#17` is a small correctness fix that should stay publishable on its own.
+- What remains: finish publishing the clean replacement for PR `#8`, then review and merge or replace the still-open PRs `#5`, `#7`, and `#6`.
+- Why deferred: this hosting branch should stay publishable on its own once the replacement PR is open.
 - Objective: reduce the amount of long-lived branch state that is still open after the helper/docs line landed.
-- Relevant context: `#14` and `#16` are now merged; the remaining open lines are older runtime/hosting/rawhex branches.
+- Relevant context: `#14`, `#16`, and `#18` are now merged; the remaining open lines are older runtime/hosting/rawhex branches, and `#8` now needs a clean-base replacement rather than direct merge.
 - Scope: GitHub PR management plus any minimal rebasing/replacement work needed per line.
-- Current status: all four PRs remain open at the time this branch was created.
-- Known blockers/open questions: whether each line is still reviewable as-is against current `main` or now needs a clean replacement branch.
-- Most natural next step: once issue `#17` is out, re-evaluate PR `#8` and PR `#5` first because they are the next runtime-facing lines.
+- Current status: clean replacement work for `#8` is in progress on this branch; `#5`, `#7`, and `#6` still remain open after it.
+- Known blockers/open questions: whether `#5`, `#7`, and `#6` are still reviewable as-is against current `main` or now need the same clean replacement treatment.
+- Most natural next step: publish the replacement for `#8`, then inspect `#5` next because it is the remaining runtime-facing line closest to this context.
 
 ### Repo Hygiene
 ### [P2_LATER] Normalize `PROGRESS.md` encoding for safe future updates
@@ -80,6 +80,8 @@
 - Most natural next step: close it manually or with a higher-permission token the next time GitHub hygiene is touched.
 
 ## Completed
+- [x] 2026-04-16: rebuilt the stale `#8` hosting line on a fresh `main` base with `AddCommLibCore(IConfiguration)`, `CommLibHostedService`, focused hosted-service tests, and green unit/infrastructure validation.
+- [x] 2026-04-16: merged PR `#18` for `DeviceSession` timeout cleanup and moved to the next runtime-facing line on a fresh branch.
 - [x] 2026-04-03: added `coverlet.collector` to both test projects through `Directory.Packages.props` and verified `XPlat Code Coverage` output generation for unit and infrastructure tests.
 - [x] 2026-04-03: centralized shared MSBuild defaults into `Directory.Build.props` and moved package versions into `Directory.Packages.props`, removing inline package-version declarations from the project files.
 - [x] 2026-04-03: re-validated the repo after central package management with `dotnet build commlib-codex-full.sln` and `dotnet test commlib-codex-full.sln --no-build`.

--- a/src/CommLib.Hosting/CommLib.Hosting.csproj
+++ b/src/CommLib.Hosting/CommLib.Hosting.csproj
@@ -9,5 +9,6 @@
     <ProjectReference Include="..\CommLib.Infrastructure\CommLib.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 </Project>

--- a/src/CommLib.Hosting/CommLibHostedService.cs
+++ b/src/CommLib.Hosting/CommLibHostedService.cs
@@ -1,0 +1,61 @@
+using CommLib.Application.Bootstrap;
+using CommLib.Application.Configuration;
+using CommLib.Domain.Configuration;
+using CommLib.Domain.Messaging;
+using Microsoft.Extensions.Hosting;
+
+namespace CommLib.Hosting;
+
+/// <summary>
+/// Generic Host 시작과 종료 시점에 CommLib 장치 부트스트랩과 정리를 연결합니다.
+/// </summary>
+internal sealed class CommLibHostedService : IHostedService
+{
+    private readonly DeviceBootstrapper _bootstrapper;
+    private readonly IConnectionManager _connectionManager;
+    private readonly CommLibOptions _options;
+
+    /// <summary>
+    /// <see cref="CommLibHostedService"/> 인스턴스를 초기화합니다.
+    /// </summary>
+    /// <param name="bootstrapper">호스트 시작 시 장치 연결을 수행할 부트스트래퍼입니다.</param>
+    /// <param name="connectionManager">호스트 종료 시 연결 정리를 수행할 연결 관리자입니다.</param>
+    /// <param name="options">설정 파일에서 바인딩한 CommLib 루트 옵션입니다.</param>
+    public CommLibHostedService(
+        DeviceBootstrapper bootstrapper,
+        IConnectionManager connectionManager,
+        CommLibOptions options)
+    {
+        _bootstrapper = bootstrapper;
+        _connectionManager = connectionManager;
+        _options = options;
+    }
+
+    /// <summary>
+    /// 활성화된 장치 프로필만 매핑한 뒤 호스트 시작과 함께 연결합니다.
+    /// </summary>
+    /// <param name="cancellationToken">호스트 시작 취소 토큰입니다.</param>
+    /// <returns>장치 부트스트랩 작업입니다.</returns>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var profiles = _options.Devices
+            .Where(static raw => raw.Enabled)
+            .Select(DeviceProfileMapper.Map)
+            .ToArray();
+
+        return _bootstrapper.StartAsync(profiles, cancellationToken);
+    }
+
+    /// <summary>
+    /// 호스트 종료 시 활성 CommLib 연결 리소스를 비동기로 정리합니다.
+    /// </summary>
+    /// <param name="cancellationToken">호스트 종료 취소 토큰입니다.</param>
+    /// <returns>연결 정리 작업입니다.</returns>
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_connectionManager is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/src/CommLib.Hosting/Properties/AssemblyInfo.cs
+++ b/src/CommLib.Hosting/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CommLib.Unit.Tests")]

--- a/src/CommLib.Hosting/ServiceCollectionExtensions.cs
+++ b/src/CommLib.Hosting/ServiceCollectionExtensions.cs
@@ -1,10 +1,13 @@
 using CommLib.Application.Bootstrap;
+using CommLib.Domain.Configuration;
 using CommLib.Domain.Messaging;
 using CommLib.Domain.Protocol;
 using CommLib.Domain.Transport;
 using CommLib.Infrastructure.Factories;
 using CommLib.Infrastructure.Sessions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace CommLib.Hosting;
 
@@ -20,11 +23,58 @@ public static class ServiceCollectionExtensions
     /// <returns>연쇄 호출을 위해 동일한 서비스 컬렉션을 반환합니다.</returns>
     public static IServiceCollection AddCommLibCore(this IServiceCollection services)
     {
+        ArgumentNullException.ThrowIfNull(services);
+
         services.AddSingleton<ITransportFactory, TransportFactory>();
         services.AddSingleton<IProtocolFactory, ProtocolFactory>();
         services.AddSingleton<ISerializerFactory, SerializerFactory>();
         services.AddSingleton<IConnectionManager, ConnectionManager>();
         services.AddTransient<DeviceBootstrapper>();
         return services;
+    }
+
+    /// <summary>
+    /// 설정 기반 장치 프로필 바인딩과 함께 CommLib 핵심 서비스를 등록하고 Generic Host 수명주기에 연결합니다.
+    /// </summary>
+    /// <param name="services">서비스 컬렉션입니다.</param>
+    /// <param name="configuration">루트 설정 또는 <c>CommLib</c> 섹션입니다.</param>
+    /// <returns>연쇄 호출을 위한 동일한 서비스 컬렉션입니다.</returns>
+    public static IServiceCollection AddCommLibCore(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        AddCommLibCore(services);
+        services.AddSingleton(_ => BindCommLibOptions(configuration));
+        services.AddSingleton<IHostedService, CommLibHostedService>();
+        return services;
+    }
+
+    /// <summary>
+    /// 입력 설정에서 CommLib 루트 옵션을 바인딩합니다.
+    /// </summary>
+    /// <param name="configuration">루트 설정 또는 <c>CommLib</c> 섹션입니다.</param>
+    /// <returns>바인딩된 CommLib 옵션입니다.</returns>
+    private static CommLibOptions BindCommLibOptions(IConfiguration configuration)
+    {
+        var source = GetCommLibConfiguration(configuration);
+        var options = new CommLibOptions();
+        source.Bind(options);
+        return options;
+    }
+
+    /// <summary>
+    /// 루트 설정이 들어온 경우 <c>CommLib</c> 섹션을 우선 사용하고, 아니면 현재 섹션 자체를 사용합니다.
+    /// </summary>
+    /// <param name="configuration">검사할 설정 루트 또는 섹션입니다.</param>
+    /// <returns>CommLib 옵션을 바인딩할 실제 설정 소스입니다.</returns>
+    private static IConfiguration GetCommLibConfiguration(IConfiguration configuration)
+    {
+        var commLibSection = configuration.GetSection("CommLib");
+        return commLibSection.Exists()
+            ? commLibSection
+            : configuration;
     }
 }

--- a/tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj
+++ b/tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj
@@ -5,6 +5,8 @@
     <Description>도메인, 애플리케이션, 인프라 계층의 단위 테스트를 한곳에서 관리하는 통합 테스트 프로젝트입니다.</Description>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
@@ -16,5 +18,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\CommLib.Application\CommLib.Application.csproj" />
     <ProjectReference Include="..\..\src\CommLib.Domain\CommLib.Domain.csproj" />
+    <ProjectReference Include="..\..\src\CommLib.Hosting\CommLib.Hosting.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/CommLib.Unit.Tests/CommLibHostedServiceTests.cs
+++ b/tests/CommLib.Unit.Tests/CommLibHostedServiceTests.cs
@@ -1,0 +1,231 @@
+using System.Text.Json;
+using CommLib.Application.Bootstrap;
+using CommLib.Domain.Configuration;
+using CommLib.Domain.Messaging;
+using CommLib.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace CommLib.Unit.Tests;
+
+/// <summary>
+/// <see cref="CommLibHostedService"/>와 설정 기반 host registration 경로를 검증합니다.
+/// </summary>
+public sealed class CommLibHostedServiceTests
+{
+    /// <summary>
+    /// 활성화된 장치만 설정에서 매핑해 호스트 시작 시 연결하는지 확인합니다.
+    /// </summary>
+    [Fact]
+    public async Task StartAsync_MapsOnlyEnabledProfilesFromConfiguration()
+    {
+        var manager = new FakeConnectionManager();
+        var bootstrapper = new DeviceBootstrapper(manager);
+        var hostedService = new CommLibHostedService(
+            bootstrapper,
+            manager,
+            new CommLibOptions
+            {
+                Devices =
+                [
+                    CreateRawProfile("enabled-1", enabled: true, port: 1000),
+                    CreateInvalidRawProfile("disabled-invalid", enabled: false, port: 1001),
+                    CreateRawProfile("enabled-2", enabled: true, port: 1002)
+                ]
+            });
+
+        await hostedService.StartAsync(CancellationToken.None);
+
+        Assert.Equal(new[] { "enabled-1", "enabled-2" }, manager.ConnectedIds);
+    }
+
+    /// <summary>
+    /// 호스트 종료 시 연결 관리자의 비동기 정리를 호출하는지 확인합니다.
+    /// </summary>
+    [Fact]
+    public async Task StopAsync_DisposesConnectionManager()
+    {
+        var manager = new FakeConnectionManager();
+        var bootstrapper = new DeviceBootstrapper(manager);
+        var hostedService = new CommLibHostedService(bootstrapper, manager, new CommLibOptions());
+
+        await hostedService.StopAsync(CancellationToken.None);
+
+        Assert.Equal(1, manager.DisposeAsyncCallCount);
+    }
+
+    /// <summary>
+    /// 설정 기반 등록이 CommLib 섹션 바인딩과 hosted service wiring을 함께 구성하는지 확인합니다.
+    /// </summary>
+    [Fact]
+    public async Task AddCommLibCore_WithConfiguration_RegistersBoundOptionsAndHostedService()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+            [
+                KeyValuePair.Create<string, string?>("CommLib:Devices:0:DeviceId", "disabled-1"),
+                KeyValuePair.Create<string, string?>("CommLib:Devices:0:DisplayName", "Disabled 1"),
+                KeyValuePair.Create<string, string?>("CommLib:Devices:0:Enabled", "false"),
+                KeyValuePair.Create<string, string?>("CommLib:Devices:0:Transport:Type", "TcpClient"),
+                KeyValuePair.Create<string, string?>("CommLib:Devices:0:Transport:Host", "127.0.0.1"),
+                KeyValuePair.Create<string, string?>("CommLib:Devices:0:Transport:Port", "7001")
+            ])
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddCommLibCore(configuration);
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var commLibOptions = serviceProvider.GetRequiredService<CommLibOptions>();
+        var hostedService = Assert.Single(serviceProvider.GetServices<IHostedService>());
+
+        Assert.Single(commLibOptions.Devices);
+        Assert.IsType<CommLibHostedService>(hostedService);
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await hostedService.StopAsync(CancellationToken.None);
+    }
+
+    /// <summary>
+    /// 유효한 원시 장치 프로필을 생성합니다.
+    /// </summary>
+    /// <param name="deviceId">장치 식별자입니다.</param>
+    /// <param name="enabled">활성 여부입니다.</param>
+    /// <param name="port">TCP 포트입니다.</param>
+    /// <returns>유효한 원시 장치 프로필입니다.</returns>
+    private static DeviceProfileRaw CreateRawProfile(string deviceId, bool enabled, int port)
+    {
+        return new DeviceProfileRaw
+        {
+            DeviceId = deviceId,
+            DisplayName = deviceId,
+            Enabled = enabled,
+            Transport = CreateTransportElement("127.0.0.1", port),
+            Protocol = new ProtocolOptions(),
+            Serializer = new SerializerOptions()
+        };
+    }
+
+    /// <summary>
+    /// 비활성 프로필 무시 동작을 검증하기 위한 잘못된 원시 장치 프로필을 생성합니다.
+    /// </summary>
+    /// <param name="deviceId">장치 식별자입니다.</param>
+    /// <param name="enabled">활성 여부입니다.</param>
+    /// <param name="port">TCP 포트입니다.</param>
+    /// <returns>비활성화된 잘못된 원시 장치 프로필입니다.</returns>
+    private static DeviceProfileRaw CreateInvalidRawProfile(string deviceId, bool enabled, int port)
+    {
+        return new DeviceProfileRaw
+        {
+            DeviceId = deviceId,
+            DisplayName = deviceId,
+            Enabled = enabled,
+            Transport = CreateTransportElement(string.Empty, port),
+            Protocol = new ProtocolOptions(),
+            Serializer = new SerializerOptions()
+        };
+    }
+
+    /// <summary>
+    /// 테스트용 TCP 전송 JSON 요소를 생성합니다.
+    /// </summary>
+    /// <param name="host">호스트 값입니다.</param>
+    /// <param name="port">포트 값입니다.</param>
+    /// <returns>TCP 전송 JSON 요소입니다.</returns>
+    private static JsonElement CreateTransportElement(string host, int port)
+    {
+        using var document = JsonDocument.Parse($$"""
+        {
+          "Type": "TcpClient",
+          "Host": "{{host}}",
+          "Port": {{port}}
+        }
+        """);
+
+        return document.RootElement.Clone();
+    }
+
+    /// <summary>
+    /// 부트스트랩 테스트에 사용하는 최소 연결 관리자 구현입니다.
+    /// </summary>
+    private sealed class FakeConnectionManager : IConnectionManager, IAsyncDisposable
+    {
+        /// <summary>
+        /// 연결 시도가 들어온 장치 식별자 목록입니다.
+        /// </summary>
+        public List<string> ConnectedIds { get; } = new();
+
+        /// <summary>
+        /// 비동기 정리 호출 횟수입니다.
+        /// </summary>
+        public int DisposeAsyncCallCount { get; private set; }
+
+        /// <summary>
+        /// 연결 요청을 기록합니다.
+        /// </summary>
+        /// <param name="profile">연결할 장치 프로필입니다.</param>
+        /// <param name="cancellationToken">작업 취소 토큰입니다.</param>
+        /// <returns>즉시 완료되는 작업입니다.</returns>
+        public Task ConnectAsync(DeviceProfile profile, CancellationToken cancellationToken = default)
+        {
+            ConnectedIds.Add(profile.DeviceId);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// 테스트에서는 연결 해제를 별도로 사용하지 않습니다.
+        /// </summary>
+        /// <param name="deviceId">연결 해제할 장치 식별자입니다.</param>
+        /// <param name="cancellationToken">작업 취소 토큰입니다.</param>
+        /// <returns>즉시 완료되는 작업입니다.</returns>
+        public Task DisconnectAsync(string deviceId, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// 테스트에서는 송신 기능을 사용하지 않습니다.
+        /// </summary>
+        /// <param name="deviceId">메시지를 보낼 장치 식별자입니다.</param>
+        /// <param name="message">전송할 메시지입니다.</param>
+        /// <param name="cancellationToken">작업 취소 토큰입니다.</param>
+        /// <returns>즉시 완료되는 작업입니다.</returns>
+        public Task SendAsync(string deviceId, IMessage message, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// 테스트에서는 수신 기능을 지원하지 않습니다.
+        /// </summary>
+        /// <param name="deviceId">메시지를 받을 장치 식별자입니다.</param>
+        /// <param name="cancellationToken">작업 취소 토큰입니다.</param>
+        /// <returns>항상 예외를 발생시킵니다.</returns>
+        public Task<IMessage> ReceiveAsync(string deviceId, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// 테스트용 구현에서는 활성 세션을 보관하지 않습니다.
+        /// </summary>
+        /// <param name="deviceId">조회할 장치 식별자입니다.</param>
+        /// <returns>항상 <see langword="null"/>입니다.</returns>
+        public IDeviceSession? GetSession(string deviceId)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// 연결 관리자 정리 호출 횟수를 증가시킵니다.
+        /// </summary>
+        /// <returns>즉시 완료되는 비동기 정리 작업입니다.</returns>
+        public ValueTask DisposeAsync()
+        {
+            DisposeAsyncCallCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a configuration-bound `AddCommLibCore(IServiceCollection, IConfiguration)` overload on top of current `main`
- add `CommLibHostedService` so enabled configured devices bootstrap on host start and the connection manager is disposed on host stop
- add focused hosted-service coverage and only the package/project references required for that path

## Why this PR exists
- supersedes the stale hosting lifecycle PR #8
- keeps the clean replacement intentionally narrow and independent from the still-open runtime-hardening line in #5

## Validation
- `dotnet restore tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj`
- `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore --filter FullyQualifiedName~CommLibHostedServiceTests`
- `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
- `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`