### PR TITLE
[codex] bound unsolicited inbound buffering

### DIFF
--- a/CHANGELOG_AGENT.md
+++ b/CHANGELOG_AGENT.md
@@ -1,157 +1,20 @@
 # CHANGELOG_AGENT
 
-## 2026-04-03
-- Reconciled `PROGRESS.md`, `AGENT.md`, `docs/current-plan.md`, recent commits, branch state, and the current WinUI example code.
-- Confirmed that the worktree was clean, the active branch name no longer matched the latest example-focused work, and no canonical root state files existed yet.
-- Initialized `CURRENT_PLAN.md`, `TODOS.md`, and `DECISIONS.md` so future sessions can resume from repo state instead of chat memory.
-- Rewrote `docs/current-plan.md` to reflect the WinUI follow-up scope instead of the earlier core-library bootstrap phase.
-- Created the branch `feat/winui-localization-foundation` before new example edits.
-- Added `AppLanguageMode`, `IAppLocalizer`, and `AppLocalizer`, then persisted language mode through the WinUI example settings file.
-- Localized the shell, Device Lab page, Settings page, transport/language choices, main status flow, and session-service connection/log output.
-- Updated the WinUI example README to document the persisted English/Korean mode.
-- Verified the localization change set with:
-  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
-  - `dotnet test commlib-codex-full.sln`
-  - a `win-x86` smoke run that stayed alive for 12 seconds (`RUNNING_OK`)
-- Added `PointerWheelScrollBridge` and attached it to page text inputs so `DeviceLabView` and `SettingsView` forward mouse-wheel events back to their parent `ScrollViewer`.
-- Verified the wheel-scroll patch with:
-  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
-  - `dotnet test commlib-codex-full.sln`
-  - a focused UI Automation smoke run that switched to `Settings` and moved the root scroll position from `0` to `40.7907907907908`
-- Tried to replay raw mouse-wheel input from the terminal for a stronger end-to-end proof, but the local automation path was not reliable enough; tracked manual pointer-device validation as follow-up instead of overstating confidence.
-- Re-ran the old `win-x64` crash investigation on the current branch state and could not reproduce the earlier `Microsoft.UI.Xaml.dll` startup fault:
-  - direct `win-x64` exe stayed alive for 12 seconds
-  - `dotnet run --project examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj -r win-x64 --no-build` stayed alive for 12 seconds
-  - explicit `win-x86` also stayed alive for 12 seconds as a comparison path
-  - Application Error / Windows Error Reporting / .NET Runtime logs stayed empty during those runs
-- Restored the WinUI example default runtime from `win-x86` back to `win-x64` and updated the README to reflect the fresh evidence instead of the stale workaround note.
-- Re-validated the restored default runtime with:
-  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
-  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj -p:RuntimeIdentifier=win-x86`
-  - `dotnet test commlib-codex-full.sln`
-  - a 12-second default `win-x64` smoke run
-  - a 12-second explicit `win-x86` smoke run
-- Replaced the old immediate `Visibility` toggling in `AppShellView` with a conservative queued fade + horizontal slide transition that keeps the existing dual-host page layout intact.
-- Verified the transition change with:
-  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
-  - `dotnet test commlib-codex-full.sln`
-  - a direct `win-x64` smoke run that found the app window and survived a scripted page-switch button sequence
-  - a direct `win-x86` regression smoke run that also survived the same page-switch button sequence
-- Reworked the `DeviceLabView` live log so it no longer wraps or gets clipped inside the page flow:
-  - kept the existing `LogText` binding
-  - gave the read-only multiline log box its own horizontal/vertical scrollbars
-  - stopped forwarding live-log wheel input to the parent page `ScrollViewer`
-  - auto-followed the newest log entry by selecting the document end after each update
-- Verified the live-log change with:
-  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
-  - `dotnet test commlib-codex-full.sln`
-  - a `win-x64` UI Automation run against the local TCP echo endpoint on `127.0.0.1:7001`
-  - a post-send `TextPattern` check showing the log reached 20 lines and the visible range still ended at the newest entry
-- Wired `DeviceLabTheme` into the real WinUI view code path instead of leaving it as unused theme scaffolding:
-  - `AppShellView`, `DeviceLabView`, and `SettingsView` now read shared background/card/typography resources from `DeviceLabTheme.Shared`
-  - kept the hookup conservative by applying safe brush/text/border resources in the existing code-built views rather than forcing a wider templated-control style rollout
-  - debugged a startup regression caused by touching `Application.Resources` too early and by stale exe locks hiding newer builds during repeated smoke runs
-  - confirmed that eager templated-control style creation can fail on missing WinUI default keys such as `DefaultListViewStyle`, so that broader theme surface is now tracked as deferred follow-up instead of shipping half-proven
-- Verified the theme hookup with:
-  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
-  - `dotnet test commlib-codex-full.sln`
-  - a fresh direct `win-x64` launch that stayed alive
-  - UI Automation detection of the `CommLib 디바이스 랩` window and its first button set after startup
-  - no `.NET Runtime` / `Application Error` / `Windows Error Reporting` events since the current successful app start
-- Updated the WinUI README to point local manual transport verification back to the existing console example helpers.
-- Tried to append planning/progress notes to `PROGRESS.md`, but kept deferring the in-place edit because `apply_patch` rejects the file as non-UTF-8; tracked encoding cleanup as backlog instead of risking history loss.
-- Reworked the WinUI transport-editing surface so it no longer shows every preset at once:
-  - `DeviceLabView` and `SettingsView` now bind each transport panel visibility to the existing `Settings.IsTcpSelected` / `IsUdpSelected` / `IsMulticastSelected` / `IsSerialSelected` state through `BooleanToVisibilityConverter`
-  - kept the current transport selector as the single source of truth instead of adding duplicate checkbox/radio visibility state
-- Added an in-app local mock-peer path directly to `Device Lab`:
-  - introduced `ILocalMockEndpointService` / `LocalMockEndpointService`
-  - `MainViewModel` now exposes localized mock start/stop commands and mock status text
-  - `DeviceLabView` now includes a localized `Mock Endpoint` card
-  - TCP and UDP mock starts pin loopback-friendly settings and open local echo peers
-  - Multicast mock starts join the selected group locally and reply back to the sender port for one-machine testing
-  - Serial intentionally remains external-only for this path
-- Verified the transport-visibility + mock-peer change set with:
-  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
-  - `dotnet test commlib-codex-full.sln`
-  - a `win-x64` UI Automation smoke that found the localized app window, confirmed the default TCP screen hid the UDP-only `Local Port` label, invoked `Start Mock`, and completed a raw TCP echo roundtrip to `127.0.0.1:7001` with payload `mock-tcp-ping`
-- Strengthened the `DeviceLabView` live-log auto-follow so it no longer relies only on moving the text selection to the end:
-  - cache the log `TextBox` inner `ScrollViewer` once the control is loaded
-  - after each log text update, enqueue a follow-up that both selects the end of the text and explicitly scrolls the inner viewer to `ScrollableHeight`
-- Re-verified the stronger live-log follow behavior with:
-  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
-  - `dotnet test commlib-codex-full.sln`
-  - a `win-x64` UI Automation smoke that started the local TCP mock, connected, sent 12 messages, and confirmed the live-log visible text range still reached the document end
-- Added Korean explanatory comments across the main WinUI example files:
-  - DI/bootstrap notes in `App.xaml.cs` and `MainWindow.xaml.cs`
-  - shell host / transition-queue rationale in `AppShellView.cs`
-  - wheel-forwarding intent in `PointerWheelScrollBridge.cs`
-  - session-state, dispatcher, and mock-peer reasoning in `MainViewModel.cs`, `DeviceLabSessionService.cs`, and `LocalMockEndpointService.cs`
-  - code-built view/localization/theme rationale in `DeviceLabView.cs`, `SettingsView.cs`, `DeviceLabTheme.cs`, and `AppLocalizer.cs`
-- Verified the comment-only pass with:
-  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
-  - `dotnet test commlib-codex-full.sln`
-- Recorded the 2026-04-03 daily progress entry in `PROGRESS.md`:
-  - `apply_patch` still could not edit the file in place because the existing stream is not valid UTF-8
-  - appended the new dated section safely instead of rewriting older bytes
-  - kept full encoding normalization as deferred repo hygiene work
-- Centralized repo-wide package/build defaults:
-  - added `Directory.Build.props` for shared `Nullable` and `ImplicitUsings`
-  - added `Directory.Packages.props` with the package versions used across WinUI, hosting, console, infrastructure, and test projects
-  - removed inline package version declarations from the existing `.csproj` files so package references stay project-specific while versions live in one root file
-- Re-validated the repo after central package management with:
-  - `dotnet build commlib-codex-full.sln`
-  - `dotnet test commlib-codex-full.sln --no-build`
-- Added coverage collection support in the test layer only:
-  - added `coverlet.collector` to `Directory.Packages.props`
-  - referenced it from `CommLib.Unit.Tests` and `CommLib.Infrastructure.Tests` with `PrivateAssets=all`
-  - kept the package out of non-test projects because it is a test collector, not a runtime/library dependency
-- Verified coverage collection with:
-  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --collect:"XPlat Code Coverage"`
-  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --collect:"XPlat Code Coverage"`
-  - Cobertura XML outputs generated under each test project's `TestResults/.../coverage.cobertura.xml`
-
 ## 2026-04-16
 
-- Created GitHub issue `#17` to track the remaining `DeviceSession` timeout-wait cleanup as its own narrow correctness slice.
-- Started `fix/issue-17-device-session-timeout-cleanup` from the current `commlib-hub/main` so the preserved dirty worktrees and the merged helper/docs line stay isolated from this fix.
-- Narrowed the implementation to `DeviceSession` timeout cleanup only:
-  - added per-request timeout registrations via private `CancellationTokenSource` storage
-  - cancel and dispose those registrations immediately when a response completes before the timeout
-  - dispose timeout registrations after timeout expiry removes the pending request entry
-  - kept the current pending-response storage contract intact instead of widening into the reflection-removal refactor in the same branch
-- Added focused unit coverage for the new cleanup path:
-  - `TryCompleteResponse_CompletesResponse_CancelsPendingTimeoutRegistration`
-  - timeout tests now also assert that the timeout-registration map returns to zero after expiry
-- Verified the fix with:
-  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore --filter "FullyQualifiedName~DeviceSessionTests"`
-  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
-  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~ConnectionManagerTests"`
-- Started `feat/hosting-lifecycle-wiring-main-base` from the current `commlib-hub/main` after PR `#18` so the Generic Host lifecycle line could be rebuilt without the stale branch drift in PR `#8`.
-- Rebuilt the hosting-lifecycle slice on that clean base:
-  - added `AddCommLibCore(this IServiceCollection, IConfiguration)` to bind `CommLibOptions`
-  - added `CommLibHostedService` to start enabled configured devices through `DeviceBootstrapper`
-  - disposed `IConnectionManager` on host stop
-  - added `InternalsVisibleTo("CommLib.Unit.Tests")` plus focused `CommLibHostedServiceTests`
-  - added only the package/project references needed for the hosting test path
-- Verified the clean hosting replacement with:
+- Created GitHub issue `#21` to track bounded unsolicited inbound buffering as its own clean runtime slice after the earlier PR / issue lines were cleaned up.
+- Started `feat/issue-21-bounded-inbound-buffering` from the current `commlib-hub/main` so the next runtime change would stay isolated from preserved dirty worktrees.
+- Ported the bounded unsolicited inbound buffering slice only:
+  - added a default inbound queue capacity of `256` to `ConnectionManager`
+  - let the internal `ConnectionManager` constructor accept an explicit `inboundQueueCapacity`
+  - replaced the unsolicited inbound `Channel.CreateUnbounded` path with a bounded channel using `BoundedChannelFullMode.Wait`
+  - kept disconnect / reconnect cleanup correct even when the receive pump is blocked on a full inbound queue
+- Added focused infrastructure coverage for the new queueing behavior:
+  - `ReceivePump_WithBoundedInboundQueue_BackpressuresTransportUntilConsumerDrains`
+  - `DisconnectAsync_WhenReceivePumpIsBackpressured_CleansUpBlockedWriterAndAllowsReconnect`
+- Verified the slice with:
+  - `dotnet restore tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj`
   - `dotnet restore tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj`
-  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore --filter "FullyQualifiedName~CommLibHostedServiceTests"`
-  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~ReceivePump_WithBoundedInboundQueue_BackpressuresTransportUntilConsumerDrains|FullyQualifiedName~DisconnectAsync_WhenReceivePumpIsBackpressured_CleansUpBlockedWriterAndAllowsReconnect"`
   - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
-- Started `feat/runtime-hardening-stack-on-19` from `feat/hosting-lifecycle-wiring-main-base` so the stale runtime PR `#5` could be rebuilt as smaller clean slices instead of one oversized replacement.
-- Ported the first runtime-hardening slice only:
-  - narrowed `ProtocolOptions` to the live `LengthPrefixed` framing contract
-  - passed `MaxFrameLength` into `LengthPrefixedProtocol` and enforced it during encode/decode
-  - let `DeviceSession` fail all pending responses when the session becomes terminal
-  - taught `ConnectionManager` to treat background receive failure as terminal, fail pending requests, and hide failed sessions
-  - serialized same-device `ConnectAsync()` calls so transport open does not race
-  - updated `appsettings.json`, the console example, and the WinUI view model to the narrower framing contract
-- Verified the first split runtime slice with:
-  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~LengthPrefixedProtocolTests|FullyQualifiedName~ProtocolFactoryTests|FullyQualifiedName~ConnectionManagerTests"`
-  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore --filter "FullyQualifiedName~DeviceSessionTests|FullyQualifiedName~DeviceProfileValidatorTests"`
   - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
-  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
-  - `dotnet restore examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj`
-  - `dotnet restore examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
-  - `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --no-restore`
-  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj --no-restore -nodeReuse:false -maxcpucount:1`

--- a/CURRENT_PLAN.md
+++ b/CURRENT_PLAN.md
@@ -3,44 +3,39 @@
 Date: 2026-04-16
 
 ## Goal
-Deliver the first clean replacement slice for stale PR `#5` on top of PR `#19`, limited to runtime contract hardening around `LengthPrefixed` framing, session failure handling, and terminal receive-failure semantics.
+Deliver issue `#21` as a clean `main`-based runtime slice that bounds unsolicited inbound buffering without mixing bootstrap-report, reconnect-contract, or hosting-surface changes into the same branch.
 
 ## Confirmed Facts
-- Active branch is `feat/runtime-hardening-stack-on-19`, created from `feat/hosting-lifecycle-wiring-main-base` after draft PR `#19` was published as the clean replacement for stale PR `#8`.
-- The older PR `#5` is not mergeable against current `main` and still spans too many concerns for a single safe replacement.
-- Instead of re-creating all of old `#5` at once, this branch now carries only the first runtime-hardening slice:
-  - `ProtocolOptions` is narrowed to the live `LengthPrefixed` contract
-  - `ProtocolFactory` passes `MaxFrameLength` into `LengthPrefixedProtocol`
-  - `LengthPrefixedProtocol` enforces maximum frame length on encode/decode
-  - `DeviceSession` can fail all pending responses on terminal session failure
-  - `ConnectionManager` treats background receive failure as terminal, fails pending requests, and hides failed sessions
-  - same-device `ConnectAsync()` calls are serialized so transport open does not race
-  - sample config and example consumers were updated to the narrower protocol contract
-- This branch intentionally does **not** yet pull in the later slices from old PR `#5`:
-  - no bounded unsolicited inbound queue yet
-  - no `StartWithReportAsync()` / bootstrap report path yet
-  - no hosting-level inbound queue capacity or queue-pressure event yet
-  - no reconnect doc clarification slice yet
+- Active branch is `feat/issue-21-bounded-inbound-buffering`, created from the current `commlib-hub/main` after the user cleaned up the earlier PR / issue lines.
+- GitHub tracking for this slice is issue `#21`: `Port bounded unsolicited inbound buffering as a clean runtime slice`.
+- Current `main` already includes the previously split runtime and hosting lines, so this branch does not need to restack on top of another open feature branch.
+- This branch now carries only the bounded unsolicited inbound buffering slice:
+  - `ConnectionManager` owns a default inbound queue capacity of `256`
+  - the internal constructor accepts an explicit `inboundQueueCapacity`
+  - unsolicited inbound messages now use a bounded channel created with `BoundedChannelFullMode.Wait`
+  - disconnect / reconnect cleanup keeps working even when the receive pump is blocked on a full queue
+- This branch intentionally does **not** yet add:
+  - bootstrap validation / `StartWithReportAsync()`
+  - public queue-pressure signals or hosting-level queue-capacity configuration
+  - `ReconnectOptions` wording changes
+  - `DeviceSession` reflection removal
 - Validation succeeded on 2026-04-16:
-  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~LengthPrefixedProtocolTests|FullyQualifiedName~ProtocolFactoryTests|FullyQualifiedName~ConnectionManagerTests"`
-  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore --filter "FullyQualifiedName~DeviceSessionTests|FullyQualifiedName~DeviceProfileValidatorTests"`
-  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
+  - `dotnet restore tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj`
+  - `dotnet restore tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~ReceivePump_WithBoundedInboundQueue_BackpressuresTransportUntilConsumerDrains|FullyQualifiedName~DisconnectAsync_WhenReceivePumpIsBackpressured_CleansUpBlockedWriterAndAllowsReconnect"`
   - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
-  - `dotnet restore examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj`
-  - `dotnet restore examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
-  - `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --no-restore`
-  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj --no-restore -nodeReuse:false -maxcpucount:1`
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
 
 ## Next Work Unit
-1. Commit the continuity-file updates for this first split slice.
-2. Push this branch and publish it as a stacked draft PR on top of `feat/hosting-lifecycle-wiring-main-base`.
-3. Revisit the remaining old `#5` slices one at a time, starting with bounded unsolicited inbound buffering.
+1. Commit the bounded inbound buffering slice and the continuity-file updates as separate commits.
+2. Push `feat/issue-21-bounded-inbound-buffering` to `commlib-hub`.
+3. Open a draft PR against `main` that stays limited to the bounded queue / focused tests only.
 
 ## Next Slice Design
-1. Keep this branch scoped to the runtime contract hardening already proven by the current tests and example builds.
-2. Do not add bounded queue/backpressure, bootstrap report, or reconnect wording changes into this first replacement slice.
-3. Treat any gate-lifecycle cleanup or DI-surface work discovered during review as follow-up unless it blocks this slice from staying correct.
+1. Keep this branch reviewable as one correctness / runtime-pressure slice.
+2. Treat bootstrap reporting as the next likely runtime slice after this PR is published.
+3. Keep queue-pressure signaling, DI surface expansion, and reconnect naming as separate follow-up lines unless review feedback makes them blocking.
 
 ## Stop / Reassess Conditions
-- If the stacked PR needs to base directly on `main` before `#19` merges, stop and decide whether to restack or wait rather than duplicating the host wiring diff here.
-- If new failures appear outside the runtime-contract surface, verify whether another slice from old `#5` leaked into this branch by accident.
+- If review feedback rejects `BoundedChannelFullMode.Wait` as the first policy, stop and decide whether to switch policy here or defer alternative queue-pressure semantics into a separate slice.
+- If any additional runtime changes are needed outside `ConnectionManager` and its focused tests, reassess whether they belong in this branch or in the next runtime slice.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,103 +1,13 @@
 # DECISIONS
 
-## 2026-04-03 - Prioritize localization foundation before other WinUI follow-ups
-- Context: planned follow-up work includes Korean UI mode, content transition animation, mouse-wheel scroll fixes, and `win-x64` crash investigation. The current WinUI code still hard-codes user-facing strings across multiple views and view models.
-- Decision: make localization foundation the next implementation unit before animation or runtime-specific investigation.
-- Why: it is the safest evidence-backed work unit, directly supports the planned Korean UI mode, and reduces duplicated edits across the same UI surfaces.
-- Consequences: shell/page/button/status copy should move behind a resource or localization service; animation and `win-x64` investigation remain deferred.
+## 2026-04-16 - Rebuild bounded unsolicited inbound buffering as its own `main`-based runtime slice
+- Context: after the earlier PR / issue lines were cleaned up, the next runtime-facing concern still waiting was bounded unsolicited inbound buffering. The old implementation existed inside a much larger runtime-hardening line, but that branch structure had already been decomposed.
+- Decision: re-port bounded unsolicited inbound buffering onto a fresh `main`-based branch (`feat/issue-21-bounded-inbound-buffering`) and track it with GitHub issue `#21` instead of folding it into another wider runtime branch.
+- Why: this keeps the branch strategy clean, makes review scope obvious, and avoids reintroducing stale stacked-branch coupling after the user cleared the prior PR line.
+- Consequences: this slice can be reviewed and merged independently, while bootstrap reporting, queue-pressure signaling, reconnect naming, and other runtime follow-ups remain explicit later work.
 
-## 2026-04-03 - Keep both `docs/current-plan.md` and root `CURRENT_PLAN.md` in sync for now
-- Context: repo hooks point at `docs/current-plan.md`, while the newer session continuity rules expect a root `CURRENT_PLAN.md`.
-- Decision: maintain both documents until the repo standard is unified.
-- Why: this avoids breaking the current hook workflow while still creating a canonical root state file for newer continuity rules.
-- Consequences: future planning changes should update both documents together, or explicitly retire one path as part of a dedicated cleanup.
-
-## 2026-04-03 - Split localization ownership between views and runtime services/view models
-- Context: the WinUI example builds its pages in code, with a mix of static field labels/buttons and dynamic connection/session status text emitted from view models and `DeviceLabSessionService`.
-- Decision: keep static labels/button copy localized in the views through a shared `IAppLocalizer`, while localizing dynamic status/log text at the view-model/service layer where those messages originate.
-- Why: this is the smallest structurally correct change for the current codebase and avoids forcing a broad binding refactor across every static field label.
-- Consequences: future localization work should continue to put static surface copy near the view composition code, and keep runtime status/log copy localized where the message is produced.
-
-## 2026-04-03 - Forward text-input mouse-wheel events to the page ScrollViewer instead of refactoring the WinUI page layout
-- Context: `DeviceLabView` and `SettingsView` each use a single page-level `ScrollViewer` around many `TextBox` controls, including multiline inputs. The interaction issue to address was mouse-wheel scrolling getting stuck on text-input surfaces, and the current terminal session could not justify a broader layout rewrite.
-- Decision: add a small shared `PointerWheelScrollBridge` and attach it to the page `TextBox` controls so wheel input is forwarded to the parent page `ScrollViewer`.
-- Why: this is the smallest evidence-backed change for the current code structure, aligns with WinUI guidance that mouse-wheel chaining is not covered the same way as touch/manipulation chaining, and avoids destabilizing the conservative code-built page layout.
-- Consequences: page scrolling should remain available while the pointer is over text inputs on both pages; a follow-up manual pointer-device pass should confirm whether the live log needs more nuanced conditional forwarding later.
-
-## 2026-04-03 - Remove the stale `win-x86` default workaround and restore `win-x64`
-- Context: earlier project notes said the local `win-x64` path crashed inside `Microsoft.UI.Xaml.dll`, so the sample had been pinned to `win-x86`. Fresh checks on 2026-04-03 showed direct `win-x64` launch, `dotnet run -r win-x64 --no-build`, and explicit `win-x86` all staying alive for 12 seconds with no Application Error / Windows Error Reporting / .NET Runtime events.
-- Decision: restore `examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj` to default `win-x64` and update the README instead of keeping the x86 pin based on stale evidence.
-- Why: keeping the workaround would encode an unsupported assumption into the project after the failure stopped reproducing on the current machine and branch state.
-- Consequences: `win-x64` becomes the default developer path again; if the native startup fault reappears later, future investigation should capture fresh runtime evidence before reintroducing an architecture workaround.
-
-## 2026-04-03 - Keep page transitions inside `AppShellView` and preserve the existing dual-host layout
-- Context: the WinUI shell already uses two child hosts with direct visibility toggling to avoid the earlier blank-screen issue. The user wanted smoother page switching for `Device Lab` and `Settings`, but a larger navigation/container rewrite would add more risk than value.
-- Decision: add a conservative queued fade + horizontal slide transition directly inside `AppShellView`, while keeping both page hosts alive and avoiding any broader navigation abstraction change.
-- Why: this gives noticeably smoother tab switching with the smallest structurally safe change and keeps the previously stabilized page host model intact.
-- Consequences: future tuning should stay in the transition timing/distance layer first; only a proven limitation should justify moving to a different navigation container or page-composition model.
-
-## 2026-04-03 - Keep the live log on the existing `LogText` binding and make the viewer itself scroll/auto-follow
-- Context: the WinUI example already exposes runtime logs as a single `LogText` string bound into `DeviceLabView`. The immediate problem was long or repeated real-time log output getting visually clipped instead of behaving like an operator log console.
-- Decision: keep the current `LogText` aggregation path, but turn the live-log surface into a dedicated read-only multiline `TextBox` with no-wrap lines, its own horizontal/vertical scrollbars, and end-of-document auto-follow on updates. Do not forward the live-log wheel input back to the page `ScrollViewer`.
-- Why: this is the smallest structurally correct fix for the current code shape, solves the clipping problem now, and avoids widening scope into a list-based log viewer refactor with new item templates and virtualization concerns.
-- Consequences: the live log now behaves like a scrollable console while preserving the current view-model contract; if future work needs filtering, severity styling, or very large log volumes, that should be handled as a deliberate viewer redesign instead of ad-hoc tweaks.
-
-## 2026-04-03 - Use `DeviceLabTheme` as a shared code-side palette/typography source, not as an app-wide templated-control style rollout
-- Context: `examples/CommLib.Examples.WinUI/Styles/DeviceLabTheme.cs` existed but was not consumed anywhere. A first attempt to force a broader theme rollout uncovered two runtime risks: touching `Application.Resources` too early in `App` startup, and eagerly creating templated-control styles that depended on missing default WinUI keys such as `DefaultListViewStyle`.
-- Decision: connect `DeviceLabTheme` to the live code-built views through `DeviceLabTheme.Shared` and direct lookups for safe brush/text/border resources in `AppShellView`, `DeviceLabView`, and `SettingsView`. Do not ship a full templated-control style rollout in this step.
-- Why: this makes the theme real immediately, keeps the example running on `win-x64`, and avoids expanding the task into a fragile runtime-style investigation while the user’s main objective is to have the existing UI actually honor the shared theme surface.
-- Consequences: the WinUI example now has a real shared styling source for backgrounds, card chrome, and typography, while the broader control-style surface is explicitly deferred until the available default style keys and startup-safe initialization path are mapped with evidence.
-
-## 2026-04-03 - Drive transport-panel visibility from the existing selected-transport state
-- Context: after the WinUI example grew to support TCP, UDP, Multicast, and Serial in both `DeviceLabView` and `SettingsView`, every transport panel remained visible at once. The user wanted the UI to show only the currently relevant transport path, but the existing settings view model already exposed `SelectedTransport` plus `IsTcpSelected` / `IsUdpSelected` / `IsMulticastSelected` / `IsSerialSelected`.
-- Decision: bind each transport panel visibility directly to those existing selection-derived booleans through `BooleanToVisibilityConverter` instead of introducing a second checkbox/radio source of truth.
-- Why: this is the smallest structurally correct change, preserves a single source of truth for the active transport, and avoids duplicated UI state that could drift away from the actual session configuration.
-- Consequences: both WinUI pages now collapse down to the selected transport preset, and future visibility behavior should continue to hang off the current transport-selection state unless there is a proven need for a different UX model.
-
-## 2026-04-03 - Put local mock peers inside `Device Lab` and normalize loopback-friendly settings when they start
-- Context: validating TCP/UDP/Multicast from the WinUI example previously required a second console process or external server, which made the sample harder to exercise directly from the UI. The user explicitly wanted mock peer endpoints to be openable from the UI itself.
-- Decision: add a small in-process `ILocalMockEndpointService` / `LocalMockEndpointService`, surface it through `MainViewModel` and a `Mock Endpoint` card on `DeviceLabView`, and normalize loopback-friendly settings when the user starts a mock peer.
-- Why: this keeps the test aid close to the operator workflow, avoids external-process orchestration from the UI, and makes local validation much faster while staying inside the current MVVM + DI structure.
-- Consequences: TCP/UDP/Multicast can now be exercised directly from the WinUI app on one machine; Serial still remains external-only, and single-machine multicast behavior may still need small UX clarification if the live log shows both self loopback traffic and peer echo.
-
-## 2026-04-03 - Drive live-log auto-follow by the inner `ScrollViewer`, not selection movement alone
-- Context: the WinUI live log already moved the caret to the end of the read-only multiline `TextBox`, but the user still wanted a stronger guarantee that the newest line stays visible as logs grow.
-- Decision: keep the existing read-only `TextBox` log surface, but cache its inner `ScrollViewer` and explicitly drive that viewer to `ScrollableHeight` after each text update in addition to selecting the end of the text.
-- Why: this is the smallest reliable change for the current control choice and avoids widening scope into a different log viewer control or template rewrite.
-- Consequences: the log now follows the latest entry more deterministically even without relying on focus/caret behavior, while preserving the current `LogText` binding contract.
-
-## 2026-04-03 - Add Korean comments to high-value WinUI paths, not line-by-line boilerplate
-- Context: the user asked for Korean comments in the WinUI project, but the example already has many straightforward property assignments and code-built UI sections where translation-style comments would add noise faster than they add value.
-- Decision: add Korean explanatory comments to the non-obvious WinUI paths only, focusing on lifecycle boundaries, runtime tradeoffs, state ownership, threading, visual-tree behavior, and mock-peer/runtime quirks.
-- Why: this keeps the project approachable for Korean readers without turning the code into a wall of fragile comments that merely restate obvious syntax.
-- Consequences: the main bootstrap/view/service/theme files are now easier to onboard from, while future comment additions should continue to prioritize intent and constraints over line-by-line narration.
-
-## 2026-04-03 - Centralize shared package versions and default MSBuild properties at the repo root
-- Context: package versions such as `System.IO.Ports`, `Microsoft.NET.Test.Sdk`, `xunit`, `CommunityToolkit.Mvvm`, and `Microsoft.WindowsAppSDK` were duplicated across multiple project files, and nearly every `.csproj` repeated the same `Nullable` / `ImplicitUsings` settings.
-- Decision: add a root `Directory.Packages.props` for package versions and a root `Directory.Build.props` for shared `Nullable` / `ImplicitUsings`, then remove the duplicated inline version/property declarations from each project file.
-- Why: this is the smallest structurally correct way to make package/version updates consistent across the repo without changing project-specific frameworks, runtime identifiers, or packaging behavior.
-- Consequences: future package upgrades should usually happen in one place, while individual `.csproj` files stay focused on project-specific concerns such as references, targets, runtime settings, and packability.
-
-## 2026-04-03 - Add `coverlet.collector` only to test projects, not every project
-- Context: after central package management was introduced, the next request was to install `coverlet.collector` across the repo. `coverlet.collector` is a VSTest data collector used during test execution, not a general runtime dependency for library or example projects.
-- Decision: add the package version once in `Directory.Packages.props`, then reference it only from `CommLib.Unit.Tests` and `CommLib.Infrastructure.Tests` with `PrivateAssets=all`.
-- Why: this matches the package's actual execution model, keeps non-test projects free of irrelevant dependencies, and still gives the repo-wide coverage behavior the user is aiming for because all executable tests now support `--collect:"XPlat Code Coverage"`.
-- Consequences: future coverage collection commands should run at the test-project or solution test layer; if new test projects are added later, they should opt into `coverlet.collector` the same way.
-
-## 2026-04-16 - Cancel `DeviceSession` timeout waits through per-request registrations instead of letting orphaned `Task.Delay` calls run to completion
-- Context: on current `main`, `DeviceSession` launched timeout work with fire-and-forget `Task.Delay(timeout)` calls. When a response completed early, the pending request entry disappeared, but the timeout task still stayed alive until the full delay elapsed.
-- Decision: keep the fix local to `DeviceSession` by tracking a private `CancellationTokenSource` per timed request. Timed requests now register that token source on send, response completion cancels and disposes it immediately, and the timeout path disposes it after removing the pending request.
-- Why: this is the smallest structurally correct fix for issue `#17`; it stops stale timeout waits without widening the branch into the separate reflection-removal refactor or a larger session shutdown redesign.
-- Consequences: successful responses no longer leave unnecessary timeout waits alive, focused tests can assert that timeout registrations return to zero, and any broader pending-entry abstraction can remain a later dedicated follow-up.
-
-## 2026-04-16 - Rebuild stale PR `#8` as a clean `main`-based hosting slice without pulling runtime-hardening dependencies forward
-- Context: the older Generic Host lifecycle PR `#8` is no longer mergeable against current `main` and its diff has widened into many unrelated files. The earlier implementation also depended on runtime-hardening pieces that still live in the separate stale PR `#5`.
-- Decision: rebuild PR `#8` on a fresh `main` base with only the configuration-bound hosting surface: `AddCommLibCore(IServiceCollection, IConfiguration)`, `CommLibHostedService`, and focused tests. Do not reintroduce `CommLibRuntimeOptions`, inbound queue-capacity wiring, or broader observability surface work into this branch.
-- Why: this keeps the hosting line reviewable and publishable on its own, reduces long-lived branch drift, and avoids re-coupling two stale PR lines that should stay independently reviewable.
-- Consequences: Generic Host start/stop wiring can land first as a narrow improvement, while `IConnectionEventSink`, diagnostics, health, TLS, and other runtime-surface work remain explicit follow-up backlog items.
-
-## 2026-04-16 - Split stale PR `#5` into smaller clean replacement slices stacked on the clean `#19` host branch
-- Context: old PR `#5` is also no longer mergeable against current `main` and still mixes multiple concerns: protocol/session contracts, bounded inbound buffering, bootstrap reporting, hosting queue capacity, queue-pressure signaling, and reconnect wording.
-- Decision: rebuild old `#5` as a sequence of smaller clean slices on top of `feat/hosting-lifecycle-wiring-main-base` instead of re-creating the full runtime-hardening branch at once. The first slice carries only runtime contract hardening for `LengthPrefixed` framing, `DeviceSession`, `ConnectionManager`, and the minimum config/example updates needed for that contract.
-- Why: this keeps the next runtime-facing review line small enough to validate and reason about, avoids reintroducing stale-branch drift, and preserves the ability to reorder or defer later runtime slices if review feedback changes the plan.
-- Consequences: later old-`#5` behavior now stays explicit backlog work instead of implicit branch baggage. Bounded inbound buffering, bootstrap reporting, hosting queue-capacity wiring, queue-pressure events, and reconnect wording each need their own deliberate replay or follow-up slice.
+## 2026-04-16 - Use `BoundedChannelFullMode.Wait` as the first bounded inbound policy
+- Context: the goal of this slice is to prevent unbounded unsolicited inbound growth without inventing a broader delivery policy or public runtime signal in the same change.
+- Decision: use a bounded channel with `BoundedChannelFullMode.Wait` so producers backpressure instead of dropping or replacing unsolicited inbound messages.
+- Why: `Wait` is the most conservative correctness-first policy for the current library contract because it preserves inbound data while still bounding memory usage.
+- Consequences: transport receive can stall behind consumer lag, which is acceptable for this first correctness slice; any later queue-pressure events, alternate drop policies, or host-level tuning stay explicit follow-up design work.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,125 +1,84 @@
 # TODOS
 
 ## Execution Context
-- Active branch: `feat/runtime-hardening-stack-on-19`
-- Tracking line: first split replacement slice for stale PR `#5`
-- Parent baseline: `feat/hosting-lifecycle-wiring-main-base` / draft PR `#19`
-- Branch rule: keep this branch limited to runtime contract hardening around `LengthPrefixed`, session failure handling, focused tests, and continuity updates
+- Active branch: `feat/issue-21-bounded-inbound-buffering`
+- Tracking issue: `#21`
+- Parent baseline: current `commlib-hub/main` after the merged hosting/runtime slices
+- Branch rule: keep this branch limited to bounded unsolicited inbound buffering, focused infrastructure coverage, and continuity updates
 
 ## Current TODOs
-- [ ] Publish the first split replacement for stale PR `#5` as a stacked draft PR on top of `feat/hosting-lifecycle-wiring-main-base`.
-  Scope: `ProtocolOptions`, `LengthPrefixedProtocol`, `ProtocolFactory`, `DeviceSession`, `ConnectionManager`, related tests, and only the config/example updates needed to keep those contracts compiling.
-  Validation: attach the focused runtime tests, full unit/infrastructure test runs, and the console/WinUI example builds to the stacked PR.
+- [ ] Publish issue `#21` as a narrow review branch / draft PR on top of `main`.
+  Scope: `ConnectionManager`, focused `ConnectionManagerTests`, and only the continuity-file updates needed to describe this clean slice.
+  Validation: attach the focused bounded-queue tests plus full infrastructure/unit test runs to the PR.
 
 ## Deferred Backlog
 
 ### Runtime Hardening & Correctness
-### [P1_SOON] Port bounded unsolicited inbound buffering as the next clean slice from old PR `#5`
-- What remains: replace the unbounded unsolicited inbound queue in `ConnectionManager` with a bounded queue and preserve safe disconnect/reconnect cleanup behavior.
-- Why deferred: this branch intentionally stops at runtime contract hardening so the first replacement slice stays reviewable.
-- Objective: prevent unbounded unsolicited inbound growth without mixing bootstrap, hosting, or reconnect concerns into the same PR.
-- Relevant context: old commit `6130ed4` carried this slice on top of the older runtime-hardening branch; it should now be replayed onto the current stacked clean branch instead.
-- Scope: `src/CommLib.Infrastructure/Sessions/ConnectionManager.cs` plus focused infrastructure tests.
-- Current status: not yet replayed onto the clean replacement line.
-- Known blockers/open questions: whether the first bounded mode should remain backpressure-first (`Wait`) exactly as before or whether review feedback suggests a different first policy.
-- Most natural next step: port the bounded-channel slice after this first runtime-contract PR is published.
+### [P1_SOON] Port bootstrap validation/report flow as the next clean runtime slice
+- What remains: move profile validation to the connection/bootstrap boundary and add `StartWithReportAsync()` with `DeviceBootstrapReport` / `DeviceBootstrapFailure`.
+- Why deferred: issue `#21` intentionally stops at bounded unsolicited inbound buffering so the branch stays reviewable and low-risk.
+- Objective: make bootstrap failures explicit and structured without mixing that behavior into the queueing slice.
+- Relevant context: older runtime hardening work already identified this as the next natural slice after the bounded queue change.
+- Scope: `src/CommLib.Application/Bootstrap`, `DeviceProfileValidator`, `ConnectionManager`, and focused unit/infrastructure coverage.
+- Current status: not started on the fresh `main`-based line yet.
+- Known blockers/open questions: whether validator placement should stay application-side for one intermediate slice or move directly with the replay.
+- Most natural next step: create a new issue + branch from updated `main` after this PR is published.
+
+### [P1_SOON] Decide whether queue-pressure should remain internal backpressure or become a public runtime / hosting signal
+- What remains: decide if bounded-queue pressure needs a surfaced event / metric / option beyond the current internal `Wait` behavior.
+- Why deferred: the current slice proves correctness first and intentionally avoids widening the hosting/runtime surface.
+- Objective: keep the first queue-hardening change small while leaving room for later observability and policy tuning.
+- Relevant context: `ConnectionManager` now applies bounded backpressure internally, but no public signal exists yet for operators or hosts.
+- Scope: `src/CommLib.Infrastructure/Sessions`, `src/CommLib.Hosting`, diagnostics hooks, and any follow-up tests/docs.
+- Current status: intentionally excluded from issue `#21`.
+- Known blockers/open questions: whether production callers need a signal immediately or whether logs / metrics alone are sufficient.
+- Most natural next step: revisit only after this bounded-queue slice lands and the real host/ops need is clearer.
 
 ### [P1_SOON] Replace reflection-based `TrySetResponseResult` in `DeviceSession`
 - What remains: remove the runtime `GetMethod(...).Invoke(...)` path from `TrySetResponseResult()` by introducing a typed pending-entry abstraction or another non-reflection completion path.
-- Why deferred: the first replacement slice for old PR `#5` already widened `DeviceSession` enough through terminal failure handling.
-- Objective: eliminate reflection from the hot response-completion path without widening this branch.
-- Relevant context: the current stacked runtime-contract branch still stores pending response completions as `object` in `_pendingResponses`, and the non-generic response completion path uses reflection to finish typed `TaskCompletionSource<TResponse>` instances.
+- Why deferred: it is orthogonal to issue `#21` and should stay a separate correctness/performance slice.
+- Objective: eliminate reflection from the hot response-completion path without widening the current runtime queue branch.
+- Relevant context: the current application layer still stores pending response completions as `object` in `_pendingResponses`, and the non-generic response completion path uses reflection.
 - Scope: `src/CommLib.Application/Sessions/DeviceSession.cs`, focused unit tests, and any internal helper abstraction that replaces the reflection path.
-- Current status: reflection is still live on the non-generic path even after pending-response failure handling was added here.
-- Known blockers/open questions: whether the replacement should stay as a private nested helper in `DeviceSession` or become a reusable application-layer abstraction.
-- Most natural next step: design a private typed pending-entry wrapper and verify it with the existing `DeviceSessionTests` surface.
-
-### [P1_SOON] Port bootstrap validation/report flow as a separate clean slice from old PR `#5`
-- What remains: move profile validation to the connection/bootstrap boundary and add `StartWithReportAsync()` with `DeviceBootstrapReport` / `DeviceBootstrapFailure`.
-- Why deferred: this is a second independent behavior change and would make the first replacement slice too large.
-- Objective: keep bootstrap failure handling explicit without coupling it to queueing or host-wiring concerns.
-- Relevant context: old commit `994eeb6` carried this behavior and also moved `DeviceProfileValidator`; it now needs a fresh replay on top of the stacked clean branch.
-- Scope: `src/CommLib.Application/Bootstrap`, `DeviceProfileValidator`, `ConnectionManager`, and focused unit/infrastructure coverage.
-- Current status: not yet replayed onto the clean replacement line.
-- Known blockers/open questions: whether the validator should remain in `CommLib.Application` for one intermediate slice or move directly to `CommLib.Domain.Configuration` during the replay.
-- Most natural next step: port this after the bounded-queue slice unless review feedback suggests bootstrap correctness should land first.
+- Current status: still pending after the timeout-cleanup work merged earlier today.
+- Known blockers/open questions: whether the replacement should stay as a private nested helper or become a reusable application-layer abstraction.
+- Most natural next step: design a private typed pending-entry wrapper and verify it through the existing `DeviceSessionTests`.
 
 ### Production Integration & Hosting
 ### [P1_SOON] Expose `IConnectionEventSink` through DI without coupling callers to `ConnectionManager` internals
 - What remains: give `AddCommLibCore()` a DI-friendly way to accept an `IConnectionEventSink` implementation.
-- Why deferred: `#19` intentionally stays at Generic Host start/stop wiring only, and this first runtime slice also avoids widening the hosting surface.
+- Why deferred: issue `#21` is intentionally runtime-internal only and should not widen the hosting surface.
 - Objective: let production callers wire logging and metrics without reflection or internal constructor knowledge.
-- Relevant context: `ConnectionManager` already accepts an optional `IConnectionEventSink`, and later old-`#5` slices also depend on that seam for queue-pressure events.
+- Relevant context: `ConnectionManager` already accepts an optional `IConnectionEventSink`, and later queue-pressure work may want the same seam.
 - Scope: `src/CommLib.Hosting`, `src/CommLib.Infrastructure/Sessions`, and any resulting interface-boundary adjustment.
-- Current status: still deferred outside the current clean host/runtime split.
+- Current status: still deferred outside the current bounded-queue slice.
 - Known blockers/open questions: whether the sink should stay in infrastructure or move upward so hosting can reference it more cleanly.
-- Most natural next step: revisit this after the replacement PR for `#8` is published and the hosting layer is back on a clean base.
+- Most natural next step: revisit after the queue slice and bootstrap slice have landed cleanly.
 
 ### API / Contract Truthfulness
 ### [P1_SOON] Decide whether `ReconnectOptions` naming is still too broad for connect-time retry only
 - What remains: choose between doc-only clarification, a staged alias/deprecation path, or a later breaking rename.
-- Why deferred: the reconnect wording belongs to a later old-`#5` slice and is not necessary for the first runtime-contract replacement to stand up.
+- Why deferred: reconnect wording is unrelated to the queueing slice and should not be bundled into issue `#21`.
 - Objective: keep the public configuration surface truthful without unnecessary compatibility churn.
-- Relevant context: the runtime-contract slice now makes terminal receive-failure behavior more explicit, which increases the value of clarifying that `ReconnectOptions` still covers connect-time retry only.
+- Relevant context: receive-failure behavior is already explicit, but reconnect configuration still only covers connect-time retry semantics.
 - Scope: `src/CommLib.Domain/Configuration/ReconnectOptions.cs`, `DeviceProfile`, docs, and any compatibility shim if a staged alias is chosen.
-- Current status: still pending as a later clean slice after the core behavior change lands.
+- Current status: still pending as a later clean slice.
 - Known blockers/open questions: how much external dependency exists on the current property/type names.
 - Most natural next step: inventory references before changing names.
-
-### Review & Delivery
-### [P1_SOON] Resolve the longer-lived open review lines on top of current `main`
-- What remains: publish this first split replacement for old `#5`, then continue replacing the remaining old-`#5` slices before returning to PRs `#7` and `#6`.
-- Why deferred: this branch should stay publishable as one narrow runtime slice before more old-`#5` behavior is layered on.
-- Objective: reduce the amount of long-lived branch state that is still open after the helper/docs line landed.
-- Relevant context: `#14`, `#16`, and `#18` are merged; `#19` is now the clean replacement for old `#8`; old `#5`, `#7`, and `#6` still remain open, but `#5` is being decomposed into smaller clean replacements.
-- Scope: GitHub PR management plus any minimal rebasing/replacement work needed per line.
-- Current status: `#19` is open as the clean `#8` replacement; the first split replacement for old `#5` is now implemented locally on this branch; `#7` and `#6` remain untouched after that.
-- Known blockers/open questions: whether later old-`#5` slices should keep stacking on `#19` / this branch or wait until `#19` lands on `main`.
-- Most natural next step: publish this stacked slice, then port the bounded inbound queue slice next.
 
 ### Repo Hygiene
 ### [P2_LATER] Normalize `PROGRESS.md` encoding for safe future updates
 - What remains: rewrite `PROGRESS.md` into a stable UTF-8 form without losing history.
-- Why deferred: it is orthogonal to issue `#17`, and a careless rewrite could damage project memory.
+- Why deferred: it is orthogonal to issue `#21`, and a careless rewrite could damage project memory.
 - Objective: make future progress updates safe for normal in-place editing.
-- Relevant context: `apply_patch` still rejects in-place edits on some worktrees because `PROGRESS.md` contains non-UTF-8 or mixed-encoding content.
+- Relevant context: some repo files still require deliberate encoding handling during edits.
 - Scope: `PROGRESS.md` only.
 - Current status: still deferred.
 - Known blockers/open questions: the precise legacy encoding mix and the safest normalization path.
-- Most natural next step: back up the file and normalize it in one deliberate hygiene-focused branch.
-
-### GitHub Hygiene
-### [P3_NICE] Close stale issue `#11` once GitHub permissions allow it
-- What remains: close GitHub issue `#11`, which describes the already-completed helper-backed WinUI validation pass.
-- Why deferred: the current PAT could not close or comment on issues even though PR merge operations succeeded.
-- Objective: keep the repo issue list aligned with actual completed work.
-- Relevant context: issue `#11` is the only remaining open issue after issues `#9` and `#12` were auto-closed by merged PRs.
-- Scope: GitHub issue state only.
-- Current status: still open because of PAT permission limits, not because validation remains incomplete.
-- Known blockers/open questions: whether the token permissions will be widened or whether this must be closed manually in the browser.
-- Most natural next step: close it manually or with a higher-permission token the next time GitHub hygiene is touched.
+- Most natural next step: back up the file and normalize it in one hygiene-focused branch.
 
 ## Completed
+- [x] 2026-04-16: ported bounded unsolicited inbound buffering onto `feat/issue-21-bounded-inbound-buffering` with a bounded `Wait` channel, reconnect-safe cleanup, and focused/full validation.
 - [x] 2026-04-16: implemented the first split replacement slice for stale PR `#5` on top of `#19`, covering `LengthPrefixed` contract narrowing, max-frame enforcement, terminal receive failure handling, and matching focused/full validation.
 - [x] 2026-04-16: rebuilt the stale `#8` hosting line on a fresh `main` base with `AddCommLibCore(IConfiguration)`, `CommLibHostedService`, focused hosted-service tests, and green unit/infrastructure validation.
 - [x] 2026-04-16: merged PR `#18` for `DeviceSession` timeout cleanup and moved to the next runtime-facing line on a fresh branch.
-- [x] 2026-04-03: added `coverlet.collector` to both test projects through `Directory.Packages.props` and verified `XPlat Code Coverage` output generation for unit and infrastructure tests.
-- [x] 2026-04-03: centralized shared MSBuild defaults into `Directory.Build.props` and moved package versions into `Directory.Packages.props`, removing inline package-version declarations from the project files.
-- [x] 2026-04-03: re-validated the repo after central package management with `dotnet build commlib-codex-full.sln` and `dotnet test commlib-codex-full.sln --no-build`.
-- [x] 2026-04-03: added Korean explanatory comments to the main WinUI example files, focusing on non-obvious DI/bootstrap, shell transition, wheel forwarding, live-log auto-follow, session-state, and local mock-peer paths instead of line-by-line boilerplate comments.
-- [x] 2026-04-03: strengthened the WinUI live-log auto-follow by caching the log `TextBox` inner `ScrollViewer`, forcing it to `ScrollableHeight` after each text update, and re-verifying with a `win-x64` automation pass that still reached the document end after 12 sends.
-- [x] 2026-04-03: collapsed the WinUI transport settings in both `DeviceLabView` and `SettingsView` so only the currently selected transport panel stays visible.
-- [x] 2026-04-03: added an in-app `Mock Endpoint` card plus `ILocalMockEndpointService` / `LocalMockEndpointService` so the WinUI example can start local TCP/UDP/Multicast peers without a second process.
-- [x] 2026-04-03: verified the new mock-peer path with `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`, `dotnet test commlib-codex-full.sln`, and a `win-x64` UI Automation smoke that invoked `Start Mock`, confirmed the default TCP screen hid the UDP-only `Local Port` label, and completed a raw TCP echo roundtrip to `127.0.0.1:7001`.
-- [x] 2026-04-03: created the example-focused branch `feat/winui-localization-foundation`.
-- [x] 2026-04-03: introduced WinUI localization foundation with persisted `AppLanguageMode`, `IAppLocalizer`/`AppLocalizer`, and localized shell/page/transport/language choices.
-- [x] 2026-04-03: moved shell, Device Lab, Settings, and main connection/session status copy onto the localization path.
-- [x] 2026-04-03: verified the localization pass with `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`, `dotnet test commlib-codex-full.sln`, and a 12-second `win-x86` smoke run.
-- [x] 2026-04-03: added `PointerWheelScrollBridge` and routed `TextBox` mouse-wheel input back to the page `ScrollViewer` in `DeviceLabView` and `SettingsView`.
-- [x] 2026-04-03: re-verified the wheel-scroll change with `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`, `dotnet test commlib-codex-full.sln`, and a focused UI Automation smoke run that confirmed `Settings` navigation plus root scroll movement.
-- [x] 2026-04-03: attempted to reproduce the earlier local `win-x64` startup crash, but direct `win-x64` launch and `dotnet run -r win-x64 --no-build` both stayed alive for 12 seconds with no Application Error / Windows Error Reporting / .NET Runtime events.
-- [x] 2026-04-03: restored the WinUI example default runtime from `win-x86` back to `win-x64`, updated the README note, and re-validated default `win-x64` plus explicit `win-x86` smoke runs.
-- [x] 2026-04-03: added a conservative `AppShellView` fade + horizontal slide transition for `Device Lab` <-> `Settings` while keeping the existing dual-host page structure.
-- [x] 2026-04-03: verified the transition change with `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`, `dotnet test commlib-codex-full.sln`, and direct `win-x64` / `win-x86` page-switch smoke runs that kept the app alive.
-- [x] 2026-04-03: changed the `DeviceLabView` live log into a scrollable read-only multiline log surface with no-wrap lines and end-of-document auto-follow, then re-verified it with WinUI build/tests plus a local `win-x64` TCP echo automation pass that kept the visible log range pinned to the latest entry at 20 lines.
-- [x] 2026-04-03: turned `DeviceLabTheme` into a live shared source for WinUI backgrounds, card chrome, and typography in `AppShellView`, `DeviceLabView`, and `SettingsView`, then re-verified the example with build/tests plus a successful direct `win-x64` launch and UI Automation window detection.

--- a/src/CommLib.Infrastructure/Sessions/ConnectionManager.cs
+++ b/src/CommLib.Infrastructure/Sessions/ConnectionManager.cs
@@ -15,11 +15,14 @@ namespace CommLib.Infrastructure.Sessions;
 /// </summary>
 public sealed class ConnectionManager : IConnectionManager, IAsyncDisposable
 {
+    private const int DefaultInboundQueueCapacity = 256;
+
     private readonly ITransportFactory _transportFactory;
     private readonly IProtocolFactory _protocolFactory;
     private readonly ISerializerFactory _serializerFactory;
     private readonly IConnectionEventSink _eventSink;
     private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+    private readonly int _inboundQueueCapacity;
     private readonly object _syncRoot = new();
     private readonly Dictionary<string, DeviceConnectionState> _connections = new(StringComparer.Ordinal);
     private readonly Dictionary<string, SemaphoreSlim> _deviceOperationGates = new(StringComparer.Ordinal);
@@ -50,13 +53,20 @@ public sealed class ConnectionManager : IConnectionManager, IAsyncDisposable
         IProtocolFactory protocolFactory,
         ISerializerFactory serializerFactory,
         IConnectionEventSink? eventSink,
-        Func<TimeSpan, CancellationToken, Task> delayAsync)
+        Func<TimeSpan, CancellationToken, Task> delayAsync,
+        int inboundQueueCapacity = DefaultInboundQueueCapacity)
     {
+        if (inboundQueueCapacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(inboundQueueCapacity), "Inbound queue capacity must be greater than 0.");
+        }
+
         _transportFactory = transportFactory;
         _protocolFactory = protocolFactory;
         _serializerFactory = serializerFactory;
         _eventSink = eventSink ?? NullConnectionEventSink.Instance;
         _delayAsync = delayAsync;
+        _inboundQueueCapacity = inboundQueueCapacity;
     }
 
     /// <summary>
@@ -85,7 +95,9 @@ public sealed class ConnectionManager : IConnectionManager, IAsyncDisposable
             var decoder = new MessageFrameDecoder(protocol, serializer);
             var receiver = new TransportMessageReceiver(decoder, transport);
             var session = new DeviceSession(profile.DeviceId, profile.RequestResponse);
-            var inboundQueue = Channel.CreateUnbounded<InboundEnvelope>();
+
+            // 응답으로 매칭되지 않은 inbound는 별도 bounded queue에 보관해 메모리 상한을 유지합니다.
+            var inboundQueue = CreateInboundQueue();
             var receivePumpTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             newState = new DeviceConnectionState(
@@ -322,6 +334,7 @@ public sealed class ConnectionManager : IConnectionManager, IAsyncDisposable
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            // 큐가 가득 차면 writer가 대기하므로 추가 transport 수신도 함께 backpressure를 받습니다.
         }
         catch (Exception exception)
         {
@@ -343,6 +356,19 @@ public sealed class ConnectionManager : IConnectionManager, IAsyncDisposable
     }
 
     private sealed record InboundEnvelope(IMessage? Message, Exception? Exception);
+
+    private Channel<InboundEnvelope> CreateInboundQueue()
+    {
+        var options = new BoundedChannelOptions(_inboundQueueCapacity)
+        {
+            // 메시지를 드롭하지 않고 생산자를 대기시켜 메모리 사용량을 제한합니다.
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = false,
+            SingleWriter = true
+        };
+
+        return Channel.CreateBounded<InboundEnvelope>(options);
+    }
 
     private sealed class DeviceConnectionState
     {
@@ -386,7 +412,7 @@ public sealed class ConnectionManager : IConnectionManager, IAsyncDisposable
         {
         }
     }
-
+    // 이전 연결의 잔여 inbound를 제거해 재연결 후 새 세션으로 섞여 들어오지 않게 합니다.
     private static async Task TryCloseTransportAsync(ITransport transport)
     {
         try

--- a/tests/CommLib.Infrastructure.Tests/ConnectionManagerTests.cs
+++ b/tests/CommLib.Infrastructure.Tests/ConnectionManagerTests.cs
@@ -301,6 +301,41 @@ public sealed class ConnectionManagerTests
     }
 
     /// <summary>
+    /// bounded inbound queue가 가득 차면 transport 수신도 추가로 진행되지 않고 대기하는지 확인합니다.
+    /// </summary>
+    [Fact]
+    public async Task ReceivePump_WithBoundedInboundQueue_BackpressuresTransportUntilConsumerDrains()
+    {
+        var transportFactory = new FakeTransportFactory();
+        var manager = CreateManager(
+            transportFactory: transportFactory,
+            protocolFactory: new ProtocolFactory(),
+            inboundQueueCapacity: 1);
+        var profile = CreateTcpProfile();
+        await manager.ConnectAsync(profile);
+
+        transportFactory.Transport.EnqueueInboundFrame(CreateInboundFrame(41));
+        transportFactory.Transport.EnqueueInboundFrame(CreateInboundFrame(42));
+        transportFactory.Transport.EnqueueInboundFrame(CreateInboundFrame(43));
+
+        await WaitForAsync(() => transportFactory.Transport.ReceiveCount >= 2);
+        await Task.Delay(150);
+
+        Assert.Equal(2, transportFactory.Transport.ReceiveCount);
+
+        var first = await manager.ReceiveAsync(profile.DeviceId);
+        Assert.Equal((ushort)41, first.MessageId);
+
+        await WaitForAsync(() => transportFactory.Transport.ReceiveCount == 3);
+
+        var second = await manager.ReceiveAsync(profile.DeviceId);
+        var third = await manager.ReceiveAsync(profile.DeviceId);
+
+        Assert.Equal((ushort)42, second.MessageId);
+        Assert.Equal((ushort)43, third.MessageId);
+    }
+
+    /// <summary>
     /// body가 있는 메시지는 기본 serializer 조합에서 frame payload에 본문까지 포함하는지 확인합니다.
     /// </summary>
     [Fact]
@@ -937,6 +972,41 @@ public sealed class ConnectionManagerTests
     }
 
     /// <summary>
+    /// queue pressure로 writer가 막힌 상태에서도 disconnect가 receive pump를 정리하고 재연결을 허용하는지 확인합니다.
+    /// </summary>
+    [Fact]
+    public async Task DisconnectAsync_WhenReceivePumpIsBackpressured_CleansUpBlockedWriterAndAllowsReconnect()
+    {
+        var transportFactory = new FreshTransportFactory();
+        var manager = CreateManager(
+            transportFactory: transportFactory,
+            protocolFactory: new ProtocolFactory(),
+            inboundQueueCapacity: 1);
+        var profile = CreateTcpProfile();
+        await manager.ConnectAsync(profile);
+
+        var firstTransport = transportFactory.Transports[0];
+        firstTransport.EnqueueInboundFrame(CreateInboundFrame(51));
+        firstTransport.EnqueueInboundFrame(CreateInboundFrame(52));
+        firstTransport.EnqueueInboundFrame(CreateInboundFrame(53));
+
+        await WaitForAsync(() => firstTransport.ReceiveCount >= 2);
+        await Task.Delay(150);
+
+        Assert.Equal(2, firstTransport.ReceiveCount);
+
+        await manager.DisconnectAsync(profile.DeviceId);
+
+        Assert.Null(manager.GetSession(profile.DeviceId));
+        Assert.True(firstTransport.IsClosed);
+
+        await manager.ConnectAsync(profile);
+
+        Assert.NotNull(manager.GetSession(profile.DeviceId));
+        Assert.Equal(2, transportFactory.Transports.Count);
+    }
+
+    /// <summary>
     /// disconnect 시 transport에 걸려 있던 대기 수신도 함께 종료되는지 확인합니다.
     /// </summary>
     [Fact]
@@ -1102,14 +1172,28 @@ public sealed class ConnectionManagerTests
         IProtocolFactory? protocolFactory = null,
         ISerializerFactory? serializerFactory = null,
         IConnectionEventSink? eventSink = null,
-        Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
+        Func<TimeSpan, CancellationToken, Task>? delayAsync = null,
+        int inboundQueueCapacity = 256)
     {
         return new ConnectionManager(
             transportFactory ?? new FakeTransportFactory(),
             protocolFactory ?? new FakeProtocolFactory(),
             serializerFactory ?? new FakeSerializerFactory(),
             eventSink,
-            delayAsync ?? ((_, _) => Task.CompletedTask));
+            delayAsync ?? ((_, _) => Task.CompletedTask),
+            inboundQueueCapacity);
+    }
+
+    private static byte[] CreateInboundFrame(ushort messageId)
+    {
+        var payload = System.Text.Encoding.UTF8.GetBytes(messageId.ToString());
+        var frame = new byte[payload.Length + 4];
+        frame[0] = 0x00;
+        frame[1] = 0x00;
+        frame[2] = 0x00;
+        frame[3] = (byte)payload.Length;
+        payload.CopyTo(frame.AsSpan(4));
+        return frame;
     }
 
     private static DeviceProfile CreateTcpProfile(string deviceId = "device-1", int port = 502)


### PR DESCRIPTION
## Summary
- bound unsolicited inbound buffering in `ConnectionManager` with a bounded `Wait` channel
- keep disconnect/reconnect cleanup correct when the receive pump is blocked on queue pressure
- add focused infrastructure coverage for backpressure and blocked-writer cleanup

## Why
This is the clean replacement slice for issue #21. It keeps bounded inbound buffering reviewable on its own without mixing bootstrap reporting, queue-pressure signaling, or hosting-surface expansion into the same branch.

## Validation
- `dotnet restore tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj`
- `dotnet restore tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj`
- `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~ReceivePump_WithBoundedInboundQueue_BackpressuresTransportUntilConsumerDrains|FullyQualifiedName~DisconnectAsync_WhenReceivePumpIsBackpressured_CleansUpBlockedWriterAndAllowsReconnect"`
- `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
- `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
