### PR TITLE
[codex] add bootstrap validation and reporting

### DIFF
--- a/CHANGELOG_AGENT.md
+++ b/CHANGELOG_AGENT.md
@@ -2,6 +2,25 @@
 
 ## 2026-04-16
 
+- Created GitHub issue `#23` to track bootstrap validation/reporting as the next clean runtime slice stacked on top of the bounded-inbound branch.
+- Started `feat/issue-23-bootstrap-reporting` from `feat/issue-21-bounded-inbound-buffering` so the next runtime change could stay isolated and reviewable while `#22` remains open.
+- Ported the bootstrap validation/reporting slice only:
+  - validated `DeviceProfile` at the direct `ConnectionManager.ConnectAsync()` boundary before runtime factories or transport-open side effects run
+  - kept `DeviceBootstrapper.StartAsync()` fail-fast for invalid enabled profiles
+  - added `DeviceBootstrapper.StartWithReportAsync()` plus `DeviceBootstrapReport` / `DeviceBootstrapFailure`
+  - removed manual `DeviceProfileValidator` calls from the console and WinUI example connection paths so callers can rely on `ConnectAsync()` validation
+- Added focused regression coverage for the new bootstrap behavior:
+  - `StartAsync_WhenProfileIsInvalid_ThrowsBeforeConnectionManagerIsCalled`
+  - `StartWithReportAsync_WhenProfilesIncludeValidationAndConnectionFailures_ContinuesAndReturnsReport`
+  - `ConnectAsync_InvalidProfile_ThrowsBeforeRuntimeFactoriesRun`
+- Verified the slice with:
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
+  - `dotnet restore examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj`
+  - `dotnet restore examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
+  - `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --no-restore`
+  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj --no-restore -nodeReuse:false -maxcpucount:1`
+
 - Created GitHub issue `#21` to track bounded unsolicited inbound buffering as its own clean runtime slice after the earlier PR / issue lines were cleaned up.
 - Started `feat/issue-21-bounded-inbound-buffering` from the current `commlib-hub/main` so the next runtime change would stay isolated from preserved dirty worktrees.
 - Ported the bounded unsolicited inbound buffering slice only:

--- a/CURRENT_PLAN.md
+++ b/CURRENT_PLAN.md
@@ -3,39 +3,41 @@
 Date: 2026-04-16
 
 ## Goal
-Deliver issue `#21` as a clean `main`-based runtime slice that bounds unsolicited inbound buffering without mixing bootstrap-report, reconnect-contract, or hosting-surface changes into the same branch.
+Deliver issue `#23` as a clean bootstrap-validation/reporting slice on top of the bounded-inbound branch, without mixing queue-pressure signaling, reconnect-contract naming, or DI-surface expansion into the same review line.
 
 ## Confirmed Facts
-- Active branch is `feat/issue-21-bounded-inbound-buffering`, created from the current `commlib-hub/main` after the user cleaned up the earlier PR / issue lines.
-- GitHub tracking for this slice is issue `#21`: `Port bounded unsolicited inbound buffering as a clean runtime slice`.
-- Current `main` already includes the previously split runtime and hosting lines, so this branch does not need to restack on top of another open feature branch.
-- This branch now carries only the bounded unsolicited inbound buffering slice:
-  - `ConnectionManager` owns a default inbound queue capacity of `256`
-  - the internal constructor accepts an explicit `inboundQueueCapacity`
-  - unsolicited inbound messages now use a bounded channel created with `BoundedChannelFullMode.Wait`
-  - disconnect / reconnect cleanup keeps working even when the receive pump is blocked on a full queue
+- Active branch is `feat/issue-23-bootstrap-reporting`, created from `feat/issue-21-bounded-inbound-buffering` so this slice can stack directly on draft PR `#22`.
+- GitHub tracking for this slice is issue `#23`: `Port bootstrap validation/report flow as a clean runtime slice`.
+- This branch now carries only the bootstrap validation/reporting slice:
+  - `ConnectionManager.ConnectAsync()` validates `DeviceProfile` before runtime factories or transport-open side effects run
+  - `DeviceBootstrapper.StartAsync()` keeps fail-fast behavior for invalid enabled profiles
+  - `DeviceBootstrapper.StartWithReportAsync()` continues across validation/connect failures and returns `DeviceBootstrapReport`
+  - `DeviceBootstrapFailure` / `DeviceBootstrapReport` capture bootstrap failures without aborting the whole pass
+  - console and WinUI example callers no longer need to invoke `DeviceProfileValidator` manually before `ConnectAsync()`
 - This branch intentionally does **not** yet add:
-  - bootstrap validation / `StartWithReportAsync()`
-  - public queue-pressure signals or hosting-level queue-capacity configuration
+  - queue-pressure signaling or hosting-level queue-capacity options
   - `ReconnectOptions` wording changes
   - `DeviceSession` reflection removal
+  - `IConnectionEventSink` DI-surface changes
+  - `DeviceProfileValidator` namespace relocation to `CommLib.Domain`
 - Validation succeeded on 2026-04-16:
-  - `dotnet restore tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj`
-  - `dotnet restore tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj`
-  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~ReceivePump_WithBoundedInboundQueue_BackpressuresTransportUntilConsumerDrains|FullyQualifiedName~DisconnectAsync_WhenReceivePumpIsBackpressured_CleansUpBlockedWriterAndAllowsReconnect"`
-  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
   - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
+  - `dotnet restore examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj`
+  - `dotnet restore examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
+  - `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --no-restore`
+  - `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj --no-restore -nodeReuse:false -maxcpucount:1`
 
 ## Next Work Unit
-1. Commit the bounded inbound buffering slice and the continuity-file updates as separate commits.
-2. Push `feat/issue-21-bounded-inbound-buffering` to `commlib-hub`.
-3. Open a draft PR against `main` that stays limited to the bounded queue / focused tests only.
+1. Commit the bootstrap validation/reporting slice and the continuity-file updates as separate commits.
+2. Push `feat/issue-23-bootstrap-reporting` to `commlib-hub`.
+3. Open a stacked draft PR against `feat/issue-21-bounded-inbound-buffering`.
 
 ## Next Slice Design
-1. Keep this branch reviewable as one correctness / runtime-pressure slice.
-2. Treat bootstrap reporting as the next likely runtime slice after this PR is published.
-3. Keep queue-pressure signaling, DI surface expansion, and reconnect naming as separate follow-up lines unless review feedback makes them blocking.
+1. Keep this branch reviewable as one bootstrap-correctness/reporting slice.
+2. Treat queue-pressure signaling as the next likely runtime/hosting follow-up after this PR is published.
+3. Revisit `DeviceProfileValidator` relocation only if review feedback shows the current namespace placement is actively hurting clarity or coupling.
 
 ## Stop / Reassess Conditions
-- If review feedback rejects `BoundedChannelFullMode.Wait` as the first policy, stop and decide whether to switch policy here or defer alternative queue-pressure semantics into a separate slice.
-- If any additional runtime changes are needed outside `ConnectionManager` and its focused tests, reassess whether they belong in this branch or in the next runtime slice.
+- If review feedback insists that bootstrap validation must move to `CommLib.Domain` in the same line, decide explicitly whether to widen this branch or defer the move into a separate configuration-ownership slice.
+- If additional behavior is needed outside bootstrap/reporting and direct `ConnectAsync()` validation, reassess whether it belongs here or in the next runtime slice.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,5 +1,17 @@
 # DECISIONS
 
+## 2026-04-16 - Stack bootstrap validation/reporting on top of the bounded-inbound branch instead of waiting for `main`
+- Context: issue `#23` is the next runtime slice, but issue `#21` / PR `#22` is still open. Waiting for `#22` to merge would stall the current implementation flow even though the bounded-queue slice is already isolated and reviewable.
+- Decision: build `feat/issue-23-bootstrap-reporting` on top of `feat/issue-21-bounded-inbound-buffering` and publish it as a stacked PR while `#22` remains open.
+- Why: this preserves the branch strategy, keeps each slice small, and avoids folding bootstrap reporting into the bounded-queue branch just because the earlier PR has not merged yet.
+- Consequences: PR ordering matters (`#22` first, then the stacked bootstrap PR), and if `#22` merges before review completes, the bootstrap PR can later be retargeted or restacked onto `main`.
+
+## 2026-04-16 - Keep `DeviceProfileValidator` in `CommLib.Application.Configuration` for the bootstrap slice
+- Context: the older bootstrap-report commit also moved `DeviceProfileValidator` into `CommLib.Domain.Configuration`. That move is architecturally arguable, but it adds namespace churn across tests and examples beyond the core bootstrap/reporting behavior.
+- Decision: keep `DeviceProfileValidator` in `CommLib.Application.Configuration` for issue `#23`, while still enforcing it from both `DeviceBootstrapper` and `ConnectionManager.ConnectAsync()`.
+- Why: this is the smallest structurally correct change for the current stack because it gives direct-connect validation and bootstrap reporting now without widening the slice into ownership refactoring.
+- Consequences: validator relocation remains explicit deferred work; if review feedback or a later configuration-boundary refactor shows the current placement is too awkward, that move should happen as its own deliberate follow-up.
+
 ## 2026-04-16 - Rebuild bounded unsolicited inbound buffering as its own `main`-based runtime slice
 - Context: after the earlier PR / issue lines were cleaned up, the next runtime-facing concern still waiting was bounded unsolicited inbound buffering. The old implementation existed inside a much larger runtime-hardening line, but that branch structure had already been decomposed.
 - Decision: re-port bounded unsolicited inbound buffering onto a fresh `main`-based branch (`feat/issue-21-bounded-inbound-buffering`) and track it with GitHub issue `#21` instead of folding it into another wider runtime branch.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,64 +1,64 @@
 # TODOS
 
 ## Execution Context
-- Active branch: `feat/issue-21-bounded-inbound-buffering`
-- Tracking issue: `#21`
-- Parent baseline: current `commlib-hub/main` after the merged hosting/runtime slices
-- Branch rule: keep this branch limited to bounded unsolicited inbound buffering, focused infrastructure coverage, and continuity updates
+- Active branch: `feat/issue-23-bootstrap-reporting`
+- Tracking issue: `#23`
+- Parent baseline: `feat/issue-21-bounded-inbound-buffering` / draft PR `#22`
+- Branch rule: keep this branch limited to bootstrap validation/reporting, direct `ConnectAsync()` validation, example cleanup, focused tests, and continuity updates
 
 ## Current TODOs
-- [ ] Publish issue `#21` as a narrow review branch / draft PR on top of `main`.
-  Scope: `ConnectionManager`, focused `ConnectionManagerTests`, and only the continuity-file updates needed to describe this clean slice.
-  Validation: attach the focused bounded-queue tests plus full infrastructure/unit test runs to the PR.
+- [ ] Publish issue `#23` as a stacked draft PR on top of `feat/issue-21-bounded-inbound-buffering`.
+  Scope: `DeviceBootstrapper`, `ConnectionManager`, bootstrap result types, focused tests, and only the example cleanup needed to remove manual validator calls.
+  Validation: attach the unit/infrastructure test runs plus the console/WinUI example builds to the stacked PR.
 
 ## Deferred Backlog
 
 ### Runtime Hardening & Correctness
-### [P1_SOON] Port bootstrap validation/report flow as the next clean runtime slice
-- What remains: move profile validation to the connection/bootstrap boundary and add `StartWithReportAsync()` with `DeviceBootstrapReport` / `DeviceBootstrapFailure`.
-- Why deferred: issue `#21` intentionally stops at bounded unsolicited inbound buffering so the branch stays reviewable and low-risk.
-- Objective: make bootstrap failures explicit and structured without mixing that behavior into the queueing slice.
-- Relevant context: older runtime hardening work already identified this as the next natural slice after the bounded queue change.
-- Scope: `src/CommLib.Application/Bootstrap`, `DeviceProfileValidator`, `ConnectionManager`, and focused unit/infrastructure coverage.
-- Current status: not started on the fresh `main`-based line yet.
-- Known blockers/open questions: whether validator placement should stay application-side for one intermediate slice or move directly with the replay.
-- Most natural next step: create a new issue + branch from updated `main` after this PR is published.
-
 ### [P1_SOON] Decide whether queue-pressure should remain internal backpressure or become a public runtime / hosting signal
 - What remains: decide if bounded-queue pressure needs a surfaced event / metric / option beyond the current internal `Wait` behavior.
-- Why deferred: the current slice proves correctness first and intentionally avoids widening the hosting/runtime surface.
-- Objective: keep the first queue-hardening change small while leaving room for later observability and policy tuning.
+- Why deferred: the bounded-queue slice proved correctness first and this bootstrap slice intentionally avoids widening the hosting/runtime surface again.
+- Objective: keep queue hardening observable and tunable without diluting the current bootstrap-focused review line.
 - Relevant context: `ConnectionManager` now applies bounded backpressure internally, but no public signal exists yet for operators or hosts.
 - Scope: `src/CommLib.Infrastructure/Sessions`, `src/CommLib.Hosting`, diagnostics hooks, and any follow-up tests/docs.
-- Current status: intentionally excluded from issue `#21`.
+- Current status: intentionally excluded from issues `#21` and `#23`.
 - Known blockers/open questions: whether production callers need a signal immediately or whether logs / metrics alone are sufficient.
-- Most natural next step: revisit only after this bounded-queue slice lands and the real host/ops need is clearer.
+- Most natural next step: revisit after `#22` and this bootstrap slice are published cleanly.
 
 ### [P1_SOON] Replace reflection-based `TrySetResponseResult` in `DeviceSession`
 - What remains: remove the runtime `GetMethod(...).Invoke(...)` path from `TrySetResponseResult()` by introducing a typed pending-entry abstraction or another non-reflection completion path.
-- Why deferred: it is orthogonal to issue `#21` and should stay a separate correctness/performance slice.
-- Objective: eliminate reflection from the hot response-completion path without widening the current runtime queue branch.
-- Relevant context: the current application layer still stores pending response completions as `object` in `_pendingResponses`, and the non-generic response completion path uses reflection.
+- Why deferred: it is orthogonal to bootstrap reporting and should stay a separate correctness/performance slice.
+- Objective: eliminate reflection from the hot response-completion path without widening the current branch.
+- Relevant context: the application layer still stores pending response completions as `object` in `_pendingResponses`, and the non-generic response completion path uses reflection.
 - Scope: `src/CommLib.Application/Sessions/DeviceSession.cs`, focused unit tests, and any internal helper abstraction that replaces the reflection path.
 - Current status: still pending after the timeout-cleanup work merged earlier today.
 - Known blockers/open questions: whether the replacement should stay as a private nested helper or become a reusable application-layer abstraction.
 - Most natural next step: design a private typed pending-entry wrapper and verify it through the existing `DeviceSessionTests`.
 
+### [P2_LATER] Revisit whether `DeviceProfileValidator` should move into `CommLib.Domain`
+- What remains: decide if validator ownership should move from `CommLib.Application.Configuration` to `CommLib.Domain.Configuration`.
+- Why deferred: issue `#23` keeps the validator in place so bootstrap/reporting can land without a namespace-churn side quest.
+- Objective: reduce conceptual coupling if configuration validation ownership becomes broader than the current bootstrap/runtime entry points.
+- Relevant context: `ConnectionManager` now enforces validation at the direct connect boundary, but `CommLib.Infrastructure` already references `CommLib.Application`, so the current placement is workable.
+- Scope: validator source file, validator tests/usings, examples, and any resulting project-boundary cleanup.
+- Current status: explicitly deferred by design in this branch.
+- Known blockers/open questions: whether the current placement causes enough confusion to justify extra churn.
+- Most natural next step: reconsider only if review feedback or a later configuration-surface refactor makes the move clearly worthwhile.
+
 ### Production Integration & Hosting
 ### [P1_SOON] Expose `IConnectionEventSink` through DI without coupling callers to `ConnectionManager` internals
 - What remains: give `AddCommLibCore()` a DI-friendly way to accept an `IConnectionEventSink` implementation.
-- Why deferred: issue `#21` is intentionally runtime-internal only and should not widen the hosting surface.
+- Why deferred: this bootstrap slice is intentionally runtime/bootstrap focused and should not widen the hosting surface.
 - Objective: let production callers wire logging and metrics without reflection or internal constructor knowledge.
 - Relevant context: `ConnectionManager` already accepts an optional `IConnectionEventSink`, and later queue-pressure work may want the same seam.
 - Scope: `src/CommLib.Hosting`, `src/CommLib.Infrastructure/Sessions`, and any resulting interface-boundary adjustment.
-- Current status: still deferred outside the current bounded-queue slice.
+- Current status: still deferred outside the current stacked bootstrap line.
 - Known blockers/open questions: whether the sink should stay in infrastructure or move upward so hosting can reference it more cleanly.
-- Most natural next step: revisit after the queue slice and bootstrap slice have landed cleanly.
+- Most natural next step: revisit after the runtime queue and bootstrap slices have landed cleanly.
 
 ### API / Contract Truthfulness
 ### [P1_SOON] Decide whether `ReconnectOptions` naming is still too broad for connect-time retry only
 - What remains: choose between doc-only clarification, a staged alias/deprecation path, or a later breaking rename.
-- Why deferred: reconnect wording is unrelated to the queueing slice and should not be bundled into issue `#21`.
+- Why deferred: reconnect wording is unrelated to bootstrap reporting and should not be bundled into issue `#23`.
 - Objective: keep the public configuration surface truthful without unnecessary compatibility churn.
 - Relevant context: receive-failure behavior is already explicit, but reconnect configuration still only covers connect-time retry semantics.
 - Scope: `src/CommLib.Domain/Configuration/ReconnectOptions.cs`, `DeviceProfile`, docs, and any compatibility shim if a staged alias is chosen.
@@ -69,7 +69,7 @@
 ### Repo Hygiene
 ### [P2_LATER] Normalize `PROGRESS.md` encoding for safe future updates
 - What remains: rewrite `PROGRESS.md` into a stable UTF-8 form without losing history.
-- Why deferred: it is orthogonal to issue `#21`, and a careless rewrite could damage project memory.
+- Why deferred: it is orthogonal to issue `#23`, and a careless rewrite could damage project memory.
 - Objective: make future progress updates safe for normal in-place editing.
 - Relevant context: some repo files still require deliberate encoding handling during edits.
 - Scope: `PROGRESS.md` only.
@@ -78,6 +78,7 @@
 - Most natural next step: back up the file and normalize it in one hygiene-focused branch.
 
 ## Completed
+- [x] 2026-04-16: added bootstrap validation/reporting on `feat/issue-23-bootstrap-reporting`, including direct `ConnectAsync()` validation, `StartWithReportAsync()`, result types, example cleanup, and validation/build coverage.
 - [x] 2026-04-16: ported bounded unsolicited inbound buffering onto `feat/issue-21-bounded-inbound-buffering` with a bounded `Wait` channel, reconnect-safe cleanup, and focused/full validation.
 - [x] 2026-04-16: implemented the first split replacement slice for stale PR `#5` on top of `#19`, covering `LengthPrefixed` contract narrowing, max-frame enforcement, terminal receive failure handling, and matching focused/full validation.
 - [x] 2026-04-16: rebuilt the stale `#8` hosting line on a fresh `main` base with `AddCommLibCore(IConfiguration)`, `CommLibHostedService`, focused hosted-service tests, and green unit/infrastructure validation.

--- a/examples/CommLib.Examples.Console/Program.cs
+++ b/examples/CommLib.Examples.Console/Program.cs
@@ -2,7 +2,6 @@ using System.Buffers.Binary;
 using System.IO.Ports;
 using System.Net;
 using System.Net.Sockets;
-using CommLib.Application.Configuration;
 using CommLib.Domain.Configuration;
 using CommLib.Domain.Messaging;
 using CommLib.Infrastructure.Factories;
@@ -320,7 +319,6 @@ internal static class ExampleConsole
         IMessage outboundMessage,
         CancellationToken cancellationToken)
     {
-        DeviceProfileValidator.ValidateAndThrow(profile);
         await manager.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
         Console.WriteLine($"[send] {DescribeMessage(outboundMessage)}");
         await manager.SendAsync(profile.DeviceId, outboundMessage, cancellationToken).ConfigureAwait(false);

--- a/examples/CommLib.Examples.WinUI/Services/DeviceLabSessionService.cs
+++ b/examples/CommLib.Examples.WinUI/Services/DeviceLabSessionService.cs
@@ -1,4 +1,3 @@
-using CommLib.Application.Configuration;
 using CommLib.Domain.Configuration;
 using CommLib.Domain.Messaging;
 using CommLib.Domain.Protocol;
@@ -55,8 +54,6 @@ public sealed class DeviceLabSessionService : IDeviceLabSessionService
             // 새 연결 요청은 항상 이전 연결을 먼저 깨끗이 정리한 뒤 시작한다.
             // 이렇게 하면 Device Lab에서 transport를 바꿔 가며 반복 연결해도 상태가 누적되지 않는다.
             await DisconnectCoreAsync(CancellationToken.None, emitOfflineState: false).ConfigureAwait(false);
-            DeviceProfileValidator.ValidateAndThrow(profile);
-
             var manager = new ConnectionManager(
                 _transportFactory,
                 _protocolFactory,

--- a/src/CommLib.Application/Bootstrap/DeviceBootstrapFailure.cs
+++ b/src/CommLib.Application/Bootstrap/DeviceBootstrapFailure.cs
@@ -1,0 +1,8 @@
+namespace CommLib.Application.Bootstrap;
+
+/// <summary>
+/// 부트스트랩 중 실패한 디바이스와 원인 예외를 나타냅니다.
+/// </summary>
+/// <param name="DeviceId">실패한 디바이스 ID입니다.</param>
+/// <param name="Exception">실패 원인 예외입니다.</param>
+public sealed record DeviceBootstrapFailure(string DeviceId, Exception Exception);

--- a/src/CommLib.Application/Bootstrap/DeviceBootstrapReport.cs
+++ b/src/CommLib.Application/Bootstrap/DeviceBootstrapReport.cs
@@ -1,0 +1,35 @@
+namespace CommLib.Application.Bootstrap;
+
+/// <summary>
+/// 디바이스 부트스트랩의 성공/실패 결과를 함께 담습니다.
+/// </summary>
+public sealed class DeviceBootstrapReport
+{
+    /// <summary>
+    /// <see cref="DeviceBootstrapReport"/> 인스턴스를 초기화합니다.
+    /// </summary>
+    /// <param name="connectedDeviceIds">성공적으로 연결된 디바이스 ID 목록입니다.</param>
+    /// <param name="failures">실패한 디바이스 목록입니다.</param>
+    public DeviceBootstrapReport(
+        IReadOnlyList<string> connectedDeviceIds,
+        IReadOnlyList<DeviceBootstrapFailure> failures)
+    {
+        ConnectedDeviceIds = connectedDeviceIds;
+        Failures = failures;
+    }
+
+    /// <summary>
+    /// 성공적으로 연결된 디바이스 ID 목록입니다.
+    /// </summary>
+    public IReadOnlyList<string> ConnectedDeviceIds { get; }
+
+    /// <summary>
+    /// 실패한 디바이스와 원인 예외 목록입니다.
+    /// </summary>
+    public IReadOnlyList<DeviceBootstrapFailure> Failures { get; }
+
+    /// <summary>
+    /// 실패 항목이 하나라도 있으면 <see langword="true"/>를 반환합니다.
+    /// </summary>
+    public bool HasFailures => Failures.Count > 0;
+}

--- a/src/CommLib.Application/Bootstrap/DeviceBootstrapper.cs
+++ b/src/CommLib.Application/Bootstrap/DeviceBootstrapper.cs
@@ -1,3 +1,4 @@
+using CommLib.Application.Configuration;
 using CommLib.Domain.Configuration;
 using CommLib.Domain.Messaging;
 
@@ -41,7 +42,51 @@ public sealed class DeviceBootstrapper
                 continue;
             }
 
+            DeviceProfileValidator.ValidateAndThrow(profile);
             await _connectionManager.ConnectAsync(profile, cancellationToken);
         }
+    }
+
+    /// <summary>
+    /// 활성화된 장치 프로필을 모두 시작하고, 실패한 항목은 중단하지 않고 결과로 수집합니다.
+    /// </summary>
+    /// <param name="profiles">검사하고 연결할 장치 프로필 목록입니다.</param>
+    /// <param name="cancellationToken">부트스트랩 작업 취소 토큰입니다.</param>
+    /// <returns>성공/실패를 함께 담은 부트스트랩 결과입니다.</returns>
+    public async Task<DeviceBootstrapReport> StartWithReportAsync(
+        IEnumerable<DeviceProfile> profiles,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(profiles);
+
+        var connectedDeviceIds = new List<string>();
+        var failures = new List<DeviceBootstrapFailure>();
+
+        foreach (var profile in profiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!profile.Enabled)
+            {
+                continue;
+            }
+
+            try
+            {
+                DeviceProfileValidator.ValidateAndThrow(profile);
+                await _connectionManager.ConnectAsync(profile, cancellationToken).ConfigureAwait(false);
+                connectedDeviceIds.Add(profile.DeviceId);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                failures.Add(new DeviceBootstrapFailure(profile.DeviceId, exception));
+            }
+        }
+
+        return new DeviceBootstrapReport(connectedDeviceIds, failures);
     }
 }

--- a/src/CommLib.Infrastructure/Sessions/ConnectionManager.cs
+++ b/src/CommLib.Infrastructure/Sessions/ConnectionManager.cs
@@ -1,5 +1,6 @@
 using System.Threading.Channels;
 using System.Runtime.ExceptionServices;
+using CommLib.Application.Configuration;
 using CommLib.Application.Sessions;
 using CommLib.Domain.Configuration;
 using CommLib.Domain.Messaging;
@@ -77,8 +78,10 @@ public sealed class ConnectionManager : IConnectionManager, IAsyncDisposable
     /// <returns>등록 작업입니다.</returns>
     public async Task ConnectAsync(DeviceProfile profile, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(profile);
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposeRequested();
+        DeviceProfileValidator.ValidateAndThrow(profile);
 
         var deviceGate = await AcquireDeviceGateAsync(profile.DeviceId, cancellationToken).ConfigureAwait(false);
         DeviceConnectionState? existingState = null;

--- a/tests/CommLib.Infrastructure.Tests/ConnectionManagerTests.cs
+++ b/tests/CommLib.Infrastructure.Tests/ConnectionManagerTests.cs
@@ -30,6 +30,26 @@ public sealed class ConnectionManagerTests
         Assert.Same(profile.Transport, transportFactory.LastOptions);
     }
 
+    [Fact]
+    public async Task ConnectAsync_InvalidProfile_ThrowsBeforeRuntimeFactoriesRun()
+    {
+        var transportFactory = new FakeTransportFactory();
+        var protocolFactory = new FakeProtocolFactory();
+        var serializerFactory = new FakeSerializerFactory();
+        var manager = CreateManager(
+            transportFactory: transportFactory,
+            protocolFactory: protocolFactory,
+            serializerFactory: serializerFactory);
+        var profile = CreateInvalidTcpProfile();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => manager.ConnectAsync(profile));
+
+        Assert.Equal("[device-1] TCP Host is required.", exception.Message);
+        Assert.Null(transportFactory.LastOptions);
+        Assert.Null(protocolFactory.LastOptions);
+        Assert.Null(serializerFactory.LastOptions);
+    }
+
     /// <summary>
     /// 연결 시 프로필의 protocol 설정으로 protocol factory를 호출하는지 확인합니다.
     /// </summary>
@@ -1207,6 +1227,30 @@ public sealed class ConnectionManagerTests
             {
                 Type = "TcpClient",
                 Host = "127.0.0.1",
+                Port = port
+            },
+            Protocol = new ProtocolOptions
+            {
+                Type = "LengthPrefixed"
+            },
+            Serializer = new SerializerOptions
+            {
+                Type = "AutoBinary"
+            }
+        };
+    }
+
+    private static DeviceProfile CreateInvalidTcpProfile(string deviceId = "device-1", int port = 502)
+    {
+        return new DeviceProfile
+        {
+            DeviceId = deviceId,
+            DisplayName = deviceId,
+            Enabled = true,
+            Transport = new TcpClientTransportOptions
+            {
+                Type = "TcpClient",
+                Host = string.Empty,
                 Port = port
             },
             Protocol = new ProtocolOptions

--- a/tests/CommLib.Unit.Tests/DeviceBootstrapperTests.cs
+++ b/tests/CommLib.Unit.Tests/DeviceBootstrapperTests.cs
@@ -144,6 +144,22 @@ public sealed class DeviceBootstrapperTests
         Assert.Equal(new[] { "enabled-1", "enabled-2" }, manager.ConnectedIds);
     }
 
+    [Fact]
+    public async Task StartAsync_WhenProfileIsInvalid_ThrowsBeforeConnectionManagerIsCalled()
+    {
+        var manager = new FakeConnectionManager();
+        var bootstrapper = new DeviceBootstrapper(manager);
+        var profiles = new[]
+        {
+            CreateInvalidTcpProfile("invalid-1", enabled: true, port: 1000)
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => bootstrapper.StartAsync(profiles));
+
+        Assert.Contains("[invalid-1] TCP Host is required.", exception.Message);
+        Assert.Empty(manager.ConnectedIds);
+    }
+
     /// <summary>
     /// 연결 관리자 예외를 숨기지 않고 호출자에게 전파하는지 확인합니다.
     /// </summary>
@@ -201,6 +217,51 @@ public sealed class DeviceBootstrapperTests
         Assert.Equal(new[] { "enabled-1", "enabled-2" }, manager.ConnectedIds);
     }
 
+    [Fact]
+    public async Task StartWithReportAsync_WhenProfilesIncludeValidationAndConnectionFailures_ContinuesAndReturnsReport()
+    {
+        var manager = new FakeConnectionManager
+        {
+            ConnectAsyncHandler = profile =>
+            {
+                if (profile.DeviceId == "enabled-2")
+                {
+                    throw new InvalidOperationException("boom");
+                }
+
+                return Task.CompletedTask;
+            }
+        };
+        var bootstrapper = new DeviceBootstrapper(manager);
+
+        var profiles = new[]
+        {
+            CreateProfile("enabled-1", enabled: true, port: 1000),
+            CreateInvalidTcpProfile("invalid-1", enabled: true, port: 1001),
+            CreateProfile("enabled-2", enabled: true, port: 1002),
+            CreateProfile("enabled-3", enabled: true, port: 1003),
+            CreateProfile("disabled-1", enabled: false, port: 1004)
+        };
+
+        var report = await bootstrapper.StartWithReportAsync(profiles);
+
+        Assert.Equal(new[] { "enabled-1", "enabled-2", "enabled-3" }, manager.ConnectedIds);
+        Assert.Equal(new[] { "enabled-1", "enabled-3" }, report.ConnectedDeviceIds);
+        Assert.True(report.HasFailures);
+        Assert.Collection(
+            report.Failures,
+            failure =>
+            {
+                Assert.Equal("invalid-1", failure.DeviceId);
+                Assert.Equal("[invalid-1] TCP Host is required.", failure.Exception.Message);
+            },
+            failure =>
+            {
+                Assert.Equal("enabled-2", failure.DeviceId);
+                Assert.Equal("boom", failure.Exception.Message);
+            });
+    }
+
     private static DeviceProfile CreateProfile(string deviceId, bool enabled, int port)
     {
         return new DeviceProfile
@@ -212,6 +273,24 @@ public sealed class DeviceBootstrapperTests
             {
                 Type = "TcpClient",
                 Host = "127.0.0.1",
+                Port = port
+            },
+            Protocol = new ProtocolOptions(),
+            Serializer = new SerializerOptions()
+        };
+    }
+
+    private static DeviceProfile CreateInvalidTcpProfile(string deviceId, bool enabled, int port)
+    {
+        return new DeviceProfile
+        {
+            DeviceId = deviceId,
+            DisplayName = deviceId,
+            Enabled = enabled,
+            Transport = new TcpClientTransportOptions
+            {
+                Type = "TcpClient",
+                Host = string.Empty,
                 Port = port
             },
             Protocol = new ProtocolOptions(),


### PR DESCRIPTION
## Summary
- validate `DeviceProfile` at the direct `ConnectionManager.ConnectAsync()` boundary
- add `DeviceBootstrapper.StartWithReportAsync()` plus bootstrap result/failure types
- remove manual validator calls from console and WinUI example connection paths

## Why
This is the clean bootstrap/reporting follow-up slice for issue #23. It stays focused on bootstrap correctness and reporting, and intentionally avoids queue-pressure signaling, reconnect naming, or DI-surface expansion.

## Validation
- `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore`
- `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore`
- `dotnet restore examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj`
- `dotnet restore examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj`
- `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --no-restore`
- `dotnet build examples/CommLib.Examples.WinUI/CommLib.Examples.WinUI.csproj --no-restore -nodeReuse:false -maxcpucount:1`
