### PR TITLE
[codex] publish MIT and root policy cleanup

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,4 +1,10 @@
-# AGENT.md
+﻿# AGENT.md
+
+> Internal development workflow policy for active repository maintenance.
+> This file is not part of the public CommLib runtime or package contract.
+>
+> 이 문서는 저장소 내부 개발 워크플로우를 위한 정책 파일이며,
+> 공개 API/패키지 계약 문서가 아니다.
 
 ## 목적
 

--- a/CHANGELOG_AGENT.md
+++ b/CHANGELOG_AGENT.md
@@ -1,5 +1,8 @@
 # CHANGELOG_AGENT
 
+> Internal development continuity file for active repository maintenance.
+> Not part of the public CommLib runtime or package contract.
+
 ## 2026-04-13
 - Closed the git-delivery loop without widening the mixed worktree:
   - kept `feat/runtime-hardening-clean-base` as the clean runtime review line and updated draft PR `#5`
@@ -384,6 +387,39 @@
 
 ## 2026-04-17
 
+- Created clean branch `chore/repo-finish` from `commlib-hub/main` after finding that the local `main` worktree was left in a conflicted merge state and was not safe to continue using for repository cleanup.
+- Reused the already-published `docs(repo): clarify internal root file policy` change by cherry-picking commit `8dbfd12` onto `chore/repo-finish` instead of re-editing the same root-facing documentation by hand.
+- Restored `.github/workflows/ci.yml` onto `chore/repo-finish` from the previously validated repo-polish commit history so the branch now carries the Windows CI workflow again.
+- Rechecked GitHub cleanup state and confirmed:
+  - issues `#21` and `#23` are now closed
+  - GitHub `main` still lacks `.github/workflows/ci.yml` until this branch lands
+- Verified the branch with the same commands the restored workflow runs:
+  - `dotnet restore commlib-codex-full.sln`
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --configuration Release --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --configuration Release --no-restore`
+  - `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --configuration Release --no-restore`
+- Tried both available publication paths and recorded the remaining blocker precisely:
+  - `git push -u commlib-hub chore/repo-finish` was rejected because the available PAT lacks `workflow` scope for updating `.github/workflows/ci.yml`
+  - the GitHub app integration returned `403 Resource not accessible by integration` when asked to create the remote `chore/repo-finish` branch
+- After this branch work, the remaining explicit blockers are:
+  - publish `chore/repo-finish` (or apply commit `5655677`) with workflow-file write permission
+- The maintainer then chose MIT, and this branch now also:
+  - adds the root `LICENSE`
+  - sets `PackageLicenseExpression` to `MIT` in `Directory.Build.props`
+  - updates the root README and continuity files so the remaining blocker is publication, not license choice
+- Verified the MIT packaging path with:
+  - `dotnet pack src/CommLib.Domain/CommLib.Domain.csproj --configuration Release --no-restore -p:PackageVersion=0.1.0-local-mit -o artifacts/pack-mit`
+- After the MIT follow-up, the only explicit blocker left is publishing `chore/repo-finish` with workflow-file write permission.
+- Created fresh branch `chore/repo-publication-policy` from `commlib-hub/main` instead of reviving the merged integration branch or the divergent local `main`.
+- Chose the least disruptive root publication policy for now:
+  - keep `AGENT.md`, `CURRENT_PLAN.md`, `TODOS.md`, `CHANGELOG_AGENT.md`, `DECISIONS.md`, and `PROGRESS.md` at the repository root
+  - mark them as internal development/continuity artifacts rather than product-facing contract files
+  - keep `src/`, package metadata, and example READMEs as the public-facing contract sources
+- Repaired the public/root messaging around those files:
+  - updated `README.md` repository notes to call out the internal root files explicitly
+  - added internal-artifact headers to `AGENT.md`, `CURRENT_PLAN.md`, `TODOS.md`, and `CHANGELOG_AGENT.md`
+  - left `PROGRESS.md` content untouched because its existing encoding-normalization backlog still makes in-place edits higher risk
+- No build or test rerun was needed because this slice only changes documentation/continuity files and branch hygiene.
 - Merged the outstanding integration batch into GitHub `main` as PR `#25` (`[codex] integrate outstanding runtime and repo follow-ups`):
   - pushed local branch `codex/integrate-outstanding-work`
   - opened and merged PR `#25`

--- a/CHANGELOG_AGENT.md
+++ b/CHANGELOG_AGENT.md
@@ -410,6 +410,15 @@
 - Verified the MIT packaging path with:
   - `dotnet pack src/CommLib.Domain/CommLib.Domain.csproj --configuration Release --no-restore -p:PackageVersion=0.1.0-local-mit -o artifacts/pack-mit`
 - After the MIT follow-up, the only explicit blocker left is publishing `chore/repo-finish` with workflow-file write permission.
+- Tried every locally available publication path for `chore/repo-finish` and confirmed they all still resolve to an under-scoped PAT for workflow-file writes:
+  - default `git push`
+  - `git push` with `gh auth git-credential`
+  - `gh auth refresh --scopes workflow`
+  - Git Credential Manager browser re-login
+- Chose a safe split-publication fallback instead of leaving all repo cleanup local-only:
+  - created `chore/repo-finish-publishable` from `commlib-hub/main`
+  - copied the non-workflow subset from `chore/repo-finish` so MIT license, package metadata, root publication-policy docs, and continuity updates can still be pushed now
+  - left `.github/workflows/ci.yml` only on local branch `chore/repo-finish` as the one remaining unpublished blocker
 - Created fresh branch `chore/repo-publication-policy` from `commlib-hub/main` instead of reviving the merged integration branch or the divergent local `main`.
 - Chose the least disruptive root publication policy for now:
   - keep `AGENT.md`, `CURRENT_PLAN.md`, `TODOS.md`, `CHANGELOG_AGENT.md`, `DECISIONS.md`, and `PROGRESS.md` at the repository root

--- a/CURRENT_PLAN.md
+++ b/CURRENT_PLAN.md
@@ -1,5 +1,8 @@
 # Current Plan
 
+> Internal development continuity file for active repository maintenance.
+> Not part of the public CommLib runtime or package contract.
+
 Date: 2026-04-17
 
 ## Goal
@@ -9,41 +12,44 @@ Raise repository-level public/open-source readiness without changing the core ru
 - PR `#25` (`[codex] integrate outstanding runtime and repo follow-ups`) is now merged into `commlib-hub/main`.
 - The previously outstanding runtime/messaging/repo-polish slices are now on `main`; only GitHub-side cleanup blockers remain from this integration pass.
 - All remote feature/cleanup branches that were part of the older delivery lines have been deleted from `commlib-hub`; only `main` remains on the remote.
-- The GitHub Actions workflow file is not currently present on `main` because the available git/PAT credential could not update `.github/workflows/ci.yml`, and the GitHub app integration also returned `403 Resource not accessible by integration` for contents writes.
-- Stale issues `#21` and `#23` are still open on GitHub even though their work is already on `main`, because both the GitHub app and the available PAT lacked issue-write permission in this environment.
+- GitHub issues `#21` and `#23` are now closed because their work is already present on `main`.
+- `.github/workflows/ci.yml` is still missing from GitHub `main`, but local branch `chore/repo-finish` restores the validated workflow content and verifies it successfully.
+- Publishing `chore/repo-finish` is still blocked in this environment:
+  - `git push` rejects workflow-file updates because the available PAT lacks `workflow` scope
+  - the GitHub app integration returns `403 Resource not accessible by integration` even for remote branch creation
 - The root `README.md` is now a public-facing overview instead of an internal scratch document.
+- The maintainer has now chosen MIT, and this branch adds the root `LICENSE` file plus `PackageLicenseExpression=MIT` in `Directory.Build.props`.
 - Repository/package polish is now in place:
   - central package metadata lives in `Directory.Build.props`
+  - package license metadata now uses `MIT`
   - `README.md` is packed into NuGet packages
-  - `.github/workflows/ci.yml` has already been authored and validated locally, but it still needs to be restored onto `main`
+  - `.github/workflows/ci.yml` has been restored on this branch and still needs to land on `main`
   - root/test project descriptions were normalized to clean English text
 - XML documentation generation is now scoped to the packable library projects under `src/` rather than the entire repo, which removed test/example warning noise while keeping library documentation output enabled.
 - The remaining library-side XML warnings were fixed in:
   - `src/CommLib.Application/Sessions/DeviceSession.cs`
   - `src/CommLib.Infrastructure/Protocol/LengthPrefixedProtocol.cs`
   - `src/CommLib.Infrastructure/Sessions/ConnectionManager.cs`
-- Verification completed successfully after the repo-polish updates:
-  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore -v minimal`
-  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore -v minimal`
-  - `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --no-restore -v minimal`
-  - `dotnet pack src/CommLib.Domain/CommLib.Domain.csproj --no-restore -p:PackageVersion=0.1.0-local5 -o artifacts/pack -v minimal`
-- The generated `CommLib.Domain.0.1.0-local5.nupkg` still contains the expected package metadata, including `<readme>README.md</readme>` and the repository URL.
+- Verification completed successfully on this branch with the workflow-aligned commands:
+  - `dotnet restore commlib-codex-full.sln`
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --configuration Release --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --configuration Release --no-restore`
+  - `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --configuration Release --no-restore`
+- Verification also confirms the MIT package metadata path:
+  - `dotnet pack src/CommLib.Domain/CommLib.Domain.csproj --configuration Release --no-restore -p:PackageVersion=0.1.0-local-mit -o artifacts/pack-mit`
+- The generated `CommLib.Domain.0.1.0-local-mit.nupkg` contains the expected package metadata, including `<license type="expression">MIT</license>`, `<readme>README.md</readme>`, and the repository URL.
 - The repo is closer to public-ready, but it is not fully publication-ready yet because:
-  - there is still no root `LICENSE`
-  - internal planning/continuity files still remain exposed at the repo root
-  - `AGENT.md` is still mojibake/corrupted, so it should either be normalized or kept out of the public-facing root policy
+  - `.github/workflows/ci.yml` is restored only on local branch `chore/repo-finish` and still cannot be published from this environment
+  - root internal planning/continuity files now remain by policy as explicitly marked development artifacts
 
 ## Next Work Unit
-1. Restore `.github/workflows/ci.yml` onto `commlib-hub/main` using credentials that have workflow/file-write permission.
-2. Close stale GitHub issues `#21` and `#23` using credentials that have issue-write permission.
-3. After the GitHub-side cleanup is unblocked, return to the remaining repository publication blockers: choose a root `LICENSE`, decide the root-file publication policy, and normalize or relocate `AGENT.md` accordingly.
+1. Publish local branch `chore/repo-finish` or commits `5655677` and `a58daa3` plus the MIT follow-up from a credential that can update workflow files on GitHub.
 
 ## Next Slice Design
 1. Keep the next slice at repository/GitHub hygiene scope; do not reopen runtime or WinUI feature work.
-2. Treat the missing workflow and still-open issues as credential/permission blockers, not as product-code blockers.
-3. After a higher-scope credential is available, restore the validated workflow file first, close the stale issues second, then return to the license/root-doc policy decisions.
+2. Treat the remaining work as publication hygiene only: publish the already-prepared branch with a higher-scope credential.
+3. Do not reopen root-file relocation, runtime cleanup, or WinUI follow-up work in this branch.
 
 ## Stop / Reassess Conditions
-- Do not invent a `LICENSE` without an explicit maintainer choice.
-- Do not attempt more git or API work on `.github/workflows/ci.yml` or issue state until credentials with the necessary scopes are available.
+- Do not attempt more `git push` or GitHub app branch/file writes for `.github/workflows/ci.yml` from this environment until credentials with workflow-file write capability are available.
 - If moving or renaming root internal files would break existing automation or local workflow, stop and document the chosen boundary before editing paths.

--- a/CURRENT_PLAN.md
+++ b/CURRENT_PLAN.md
@@ -14,7 +14,8 @@ Raise repository-level public/open-source readiness without changing the core ru
 - All remote feature/cleanup branches that were part of the older delivery lines have been deleted from `commlib-hub`; only `main` remains on the remote.
 - GitHub issues `#21` and `#23` are now closed because their work is already present on `main`.
 - `.github/workflows/ci.yml` is still missing from GitHub `main`, but local branch `chore/repo-finish` restores the validated workflow content and verifies it successfully.
-- Publishing `chore/repo-finish` is still blocked in this environment:
+- This branch, `chore/repo-finish-publishable`, intentionally carries only the non-workflow subset of the repo-publication cleanup so it can still be pushed with the currently available credentials.
+- Publishing the full `chore/repo-finish` workflow-restoration branch is still blocked in this environment:
   - `git push` rejects workflow-file updates because the available PAT lacks `workflow` scope
   - the GitHub app integration returns `403 Resource not accessible by integration` even for remote branch creation
 - The root `README.md` is now a public-facing overview instead of an internal scratch document.
@@ -23,7 +24,7 @@ Raise repository-level public/open-source readiness without changing the core ru
   - central package metadata lives in `Directory.Build.props`
   - package license metadata now uses `MIT`
   - `README.md` is packed into NuGet packages
-  - `.github/workflows/ci.yml` has been restored on this branch and still needs to land on `main`
+  - `.github/workflows/ci.yml` has been restored on local branch `chore/repo-finish` and still needs to land on `main`
   - root/test project descriptions were normalized to clean English text
 - XML documentation generation is now scoped to the packable library projects under `src/` rather than the entire repo, which removed test/example warning noise while keeping library documentation output enabled.
 - The remaining library-side XML warnings were fixed in:
@@ -43,11 +44,11 @@ Raise repository-level public/open-source readiness without changing the core ru
   - root internal planning/continuity files now remain by policy as explicitly marked development artifacts
 
 ## Next Work Unit
-1. Publish local branch `chore/repo-finish` or commits `5655677` and `a58daa3` plus the MIT follow-up from a credential that can update workflow files on GitHub.
+1. Publish the remaining workflow-restoration change from local branch `chore/repo-finish` with a credential that can update workflow files on GitHub after the non-workflow cleanup branch is landed.
 
 ## Next Slice Design
 1. Keep the next slice at repository/GitHub hygiene scope; do not reopen runtime or WinUI feature work.
-2. Treat the remaining work as publication hygiene only: publish the already-prepared branch with a higher-scope credential.
+2. Treat the remaining work as publication hygiene only: land the already-pushable MIT/root-policy cleanup first, then publish the prepared workflow-restoration branch with a higher-scope credential.
 3. Do not reopen root-file relocation, runtime cleanup, or WinUI follow-up work in this branch.
 
 ## Stop / Reassess Conditions

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,5 +1,8 @@
 # DECISIONS
 
+> Internal development continuity file for active repository maintenance.
+> Not part of the public CommLib runtime or package contract.
+
 ## 2026-04-13 - Deliver the validated bitfield / WinUI follow-up as stacked feature PRs, not on the mixed runtime branch
 - Context: the active `feat/runtime-readiness-hardening` worktree still carried validated but uncommitted serializer/composer, WinUI, and focused-test changes that belonged to the raw-hex / bitfield line rather than to the next runtime-hardening slice. A clean runtime branch and draft PR `#5` already existed, so committing more work here would have recreated the same mixed review problem.
 - Decision: preserve the mixed worktree as local scratch only, replay the validated feature files onto clean feature branches, and publish them as draft PR `#7` (`feat/bitfield-endianness` -> `main`) plus stacked draft PR `#6` (`feat/bitfield-schema-log-enrichment` -> `feat/bitfield-endianness`).
@@ -245,3 +248,27 @@
 - Decision: treat the remaining workflow/issue cleanup as a credential-scope problem, not as a product-code problem. Stop after the successful PR merge and remote-branch cleanup, and leave the final GitHub-side cleanup explicit for a later pass with the correct permissions.
 - Why: inventing more local branch churn or alternative code paths would not solve the actual blocker; the missing capability is GitHub write scope for workflow files and issue state.
 - Consequences: `main` now contains the integrated code and the remote branch list is clean, but `.github/workflows/ci.yml` still needs a higher-scope write path and issues `#21` / `#23` will stay open until that credential is available.
+
+## 2026-04-17 - Keep root continuity files in place for now, but mark them as internal development artifacts
+- Context: after PR `#25`, the remaining publication blockers included the missing `LICENSE` plus a decision about whether `AGENT.md`, `CURRENT_PLAN.md`, `TODOS.md`, `CHANGELOG_AGENT.md`, `DECISIONS.md`, and `PROGRESS.md` should stay at the repository root, move elsewhere, or be retired. The repo workflow and continuity instructions still reference these paths directly, and `PROGRESS.md` still has its own encoding-cleanup backlog.
+- Decision: keep the existing root paths for now and make the policy explicit instead of moving files prematurely. Mark the continuity files as internal development artifacts in the root-facing docs/files, and defer any relocation until the workflow/automation boundary is intentionally redesigned.
+- Why: this is the smallest structurally correct publication cleanup that improves the public repo story without breaking the current local workflow, hook expectations, or continuity instructions.
+- Consequences: the repository root is now intentionally honest about which files are internal, public readers are pointed toward `src/`, package metadata, and example READMEs for the real product contract, and future relocation of these files remains possible once automation and encoding constraints are addressed.
+
+## 2026-04-17 - Finish the remaining repo-publication cleanup on a fresh branch from remote main, not on the conflicted local main worktree
+- Context: after the root publication-policy documentation pass was prepared on `chore/repo-publication-policy`, the user switched the primary worktree back to local `main`. That local `main` was later found to be in a conflicted, partially merged state and diverged significantly from `commlib-hub/main`, which made it unsafe to continue repository-cleanup work there.
+- Decision: create `chore/repo-finish` directly from `commlib-hub/main`, cherry-pick the already-reviewed root publication-policy commit onto it, and restore `.github/workflows/ci.yml` there instead of trying to salvage the conflicted local `main` index.
+- Why: this is the smallest safe path that protects the user's unresolved local `main` state while keeping the final repository-publication cleanup branch narrow and reviewable.
+- Consequences: the remaining publication cleanup is now isolated on a clean branch, GitHub `main` can receive the workflow restoration through a normal branch/PR flow, and the still-divergent local `main` worktree can be handled separately without blocking repository hygiene.
+
+## 2026-04-17 - Treat workflow publication as still blocked until a credential with workflow-file write capability is used
+- Context: `chore/repo-finish` now contains the restored `.github/workflows/ci.yml`, the root publication-policy documentation, and green local verification. However, publishing that branch from this environment failed through both available write paths.
+- Decision: keep the workflow restoration committed locally on `chore/repo-finish`, but record publication itself as the remaining blocker until a token/account with workflow-file write capability is used. Do not keep retrying the same under-scoped PAT or GitHub app integration from this environment.
+- Why: the code/doc work is complete, and repeated failed writes would not add value. The actual missing capability is permission to create/update workflow-file refs on GitHub.
+- Consequences: future work should start from the already-prepared local branch/commit (`5655677` on `chore/repo-finish`) and publish it from a higher-scope environment before addressing the still-separate `LICENSE` decision.
+
+## 2026-04-17 - Use MIT for the repository license and package metadata
+- Context: after the publication branch was fully prepared except for remote workflow-file publication, the remaining maintainer decision was which repository license to adopt.
+- Decision: use MIT, add the standard root `LICENSE` file, and set `PackageLicenseExpression` to `MIT` in `Directory.Build.props` so the NuGet package metadata stays truthful alongside the repo-level license.
+- Why: the maintainer explicitly chose MIT, and package metadata should match the repository license instead of leaving the published package surface ambiguous.
+- Consequences: the explicit license-choice blocker is now resolved locally, the remaining blocker is only publishing `chore/repo-finish`, and future package builds from this branch will carry MIT license metadata.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -272,3 +272,9 @@
 - Decision: use MIT, add the standard root `LICENSE` file, and set `PackageLicenseExpression` to `MIT` in `Directory.Build.props` so the NuGet package metadata stays truthful alongside the repo-level license.
 - Why: the maintainer explicitly chose MIT, and package metadata should match the repository license instead of leaving the published package surface ambiguous.
 - Consequences: the explicit license-choice blocker is now resolved locally, the remaining blocker is only publishing `chore/repo-finish`, and future package builds from this branch will carry MIT license metadata.
+
+## 2026-04-17 - Split publication into a pushable non-workflow branch and a separate local workflow-restoration branch
+- Context: `chore/repo-finish` contains the full repository-publication cleanup, including `.github/workflows/ci.yml`, but every available local publication path still resolves to a PAT that GitHub rejects for workflow-file updates. The GitHub app integration is also under-scoped for ref creation in this repo.
+- Decision: keep `chore/repo-finish` intact as the local source of truth for the validated workflow restoration, but create `chore/repo-finish-publishable` from `commlib-hub/main` and copy only the non-workflow cleanup onto it so the MIT license, package metadata, root-policy docs, and continuity updates can still be pushed immediately.
+- Why: this is the smallest safe way to publish the repo/license cleanup that does not depend on workflow-file write permission, while keeping the still-blocked workflow restoration explicit and reviewable.
+- Consequences: GitHub can receive most of the repo-publication cleanup now, but `.github/workflows/ci.yml` still requires a later publish from `chore/repo-finish` or an equivalent higher-scope cherry-pick.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
     <RepositoryUrl>https://github.com/parksanghoon-sys/commlib-hub</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/parksanghoon-sys/commlib-hub</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>communication;devices;tcp;udp;serial;multicast;dotnet</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 parksanghoon-sys
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,10 @@ dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj
 
 ## Repository Notes
 
-- This repository still contains internal planning and continuity files used during active development.
-  Treat the runtime behavior in `src/` and the example READMEs as the real product-facing contract.
+- This repository keeps several development-workflow artifacts at the root during active maintenance:
+  `AGENT.md`, `CURRENT_PLAN.md`, `TODOS.md`, `CHANGELOG_AGENT.md`, `DECISIONS.md`, and `PROGRESS.md`.
+  They are internal planning/continuity files, not part of the public CommLib runtime or package contract.
+- Treat the runtime behavior in `src/`, package metadata, and the example READMEs as the real product-facing contract.
+- The repository is now licensed under MIT. See [LICENSE](LICENSE).
 - CI currently validates the core libraries, console example, and both test projects on Windows.
-- A repository license file is still required before calling the repo fully open-source ready.
+- The remaining publication blocker is still the unpublished workflow-restoration branch that carries `.github/workflows/ci.yml`.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,50 +1,33 @@
 # TODOS
 
+> Internal development continuity file for active repository maintenance.
+> Not part of the public CommLib runtime or package contract.
+
 ## Execution Context
-- Active checkout: `codex/integrate-outstanding-work` (local branch only; its remote was deleted after merge because PR `#25` is already on `main`).
+- Active checkout: `chore/repo-finish` (clean branch created from `commlib-hub/main` to finish the remaining repository-publication cleanup without touching the conflicted local `main` worktree).
 - Authoritative repository/runtime baseline: `commlib-hub/main`, which now contains the earlier runtime follow-ups plus the later integration batch from PR `#25`.
 - Truth note: remote feature/cleanup branches have already been deleted; the remaining cleanup work is GitHub metadata/permission-related, not branch-integration work.
-- Execution rule: start any new product work from `commlib-hub/main` (or a fresh branch from it), not from the preserved local integration branch.
+- Execution rule: keep new cleanup/product work on fresh branches from `commlib-hub/main`, not on the preserved local integration branch or the divergent local `main`.
 
 ## Current TODOs
 Order note: keep exactly one evidence-ready next execution slice promoted at a time.
 
 - [ ] Finalize the remaining public-release blockers for the repository root.
-  Scope: restore `.github/workflows/ci.yml` on `main`, close stale issues `#21` and `#23`, then return to the root `LICENSE` / root publication policy follow-up.
-  Objective: finish the last GitHub-side and repository-facing cleanup steps after PR `#25` merged the outstanding code/branch work into `main`.
-  Validation: `.github/workflows/ci.yml` exists on `main`, `is:issue is:open` no longer returns `#21`/`#23`, and the remaining root publication blockers stay recorded truthfully.
+  Scope: publish local branch `chore/repo-finish` so the restored `.github/workflows/ci.yml`, root `LICENSE`, and MIT package metadata reach `main`.
+  Objective: finish the last repository-facing cleanup step after PR `#25` merged the outstanding code/branch work into `main`, the stale GitHub issues were closed, and MIT was chosen.
+  Validation: `.github/workflows/ci.yml` exists on `main`, issues `#21` and `#23` remain closed, root `LICENSE` exists on `main`, and `Directory.Build.props` carries MIT package metadata truthfully.
 
 ## Deferred Backlog
 ### Repository Release & Hygiene
-### [P0_NOW] Unblock the final GitHub-side cleanup with a credential that can write issues and workflow files
-- What remains: restore `.github/workflows/ci.yml` onto `commlib-hub/main` and close stale issues `#21` and `#23`.
-- Why deferred: the available git/PAT credential can push normal code but cannot update workflow files, and both the GitHub app integration and PAT-backed `gh` issue/API calls returned `403 Resource not accessible`.
-- Objective: finish the repository cleanup that remained after PR `#25` merged and the remote feature branches were deleted.
-- Relevant context: PR `#25` merged the integrated runtime/messaging/repo-polish batch into `main`, and remote feature branches were then deleted successfully. The validated workflow content already exists locally, but publishing it still needs higher GitHub write permission.
-- Scope: GitHub issue state for `#21` and `#23`, `.github/workflows/ci.yml` on `main`, and any credential/setup note needed to explain the blocker.
-- Current status: open PRs are already at zero, remote branches are already cleaned, but issue/workflow writes are still blocked by credential scope.
-- Known blockers/open questions: which higher-scope credential or installation should be used for issue/workflow writes in this repo.
-- Most natural next step: use a token/app installation with issue-write and workflow/content-write permission, restore the workflow file, close the two stale issues, and rerun a quick GitHub state check.
-
-### [P0_NOW] Choose the repository license before calling the repo open-source ready
-- What remains: decide the project license and add the corresponding root `LICENSE` file.
-- Why deferred: license selection is a maintainer/legal decision; it is not safe to guess between MIT, Apache-2.0, or another policy just to make the repo look complete.
-- Objective: make the repository legally publishable and remove the clearest remaining blocker to public release.
-- Relevant context: the new root `README.md` now explicitly states that a repository license file is still required before calling the repo fully open-source ready.
-- Scope: root `LICENSE`, `README.md` if wording needs adjustment after the choice, and any package metadata that later wants a license expression.
-- Current status: no root `LICENSE` file exists yet.
-- Known blockers/open questions: which license the maintainer actually intends to publish under.
-- Most natural next step: choose the license intentionally, add the matching file, then re-run a quick package/readme sanity check.
-
-### [P1_SOON] Decide how internal planning/continuity files should appear in a public repo
-- What remains: choose whether `AGENT.md`, `CURRENT_PLAN.md`, `TODOS.md`, `CHANGELOG_AGENT.md`, `DECISIONS.md`, and `PROGRESS.md` should stay at the repo root, move under an internal/docs folder, or remain present but explicitly marked as internal development artifacts.
-- Why deferred: the files are useful to the local workflow, but keeping them at the root affects first impressions for external users.
-- Objective: make the public root layout intentional instead of accidental.
-- Relevant context: the new root `README.md` already warns that the repository still contains internal planning and continuity files used during active development.
-- Scope: root layout, README repository notes, and any automation/local workflow that assumes those filenames/paths.
-- Current status: the files still live at the root and `AGENT.md` is still mojibake/corrupted.
-- Known blockers/open questions: whether moving these files would break current automation or whether the team prefers to keep this working style visible.
-- Most natural next step: decide the root-file policy first, then either normalize the files that stay public or move/retire the ones that should not stay at the root.
+### [P0_NOW] Publish the local workflow-restoration branch with credentials that can update workflow files
+- What remains: push or otherwise publish local branch `chore/repo-finish` so the prepared cleanup commits land on GitHub and restore `.github/workflows/ci.yml`, the MIT `LICENSE`, and MIT package metadata on `main`.
+- Why deferred: the available PAT can push normal refs but rejects workflow-file updates without `workflow` scope, and the GitHub app integration returns `403 Resource not accessible by integration` even for remote branch creation in this repo.
+- Objective: finish the last GitHub-side repository cleanup that is now fully prepared and locally verified.
+- Relevant context: `chore/repo-finish` already contains commit `45892c4` (`docs(repo): clarify internal root file policy`), commit `5655677` (`chore(repo): restore ci publication cleanup`), and the MIT follow-up that adds the root `LICENSE` and `PackageLicenseExpression=MIT`. The branch was verified locally with `dotnet restore`, both `dotnet test` projects in `Release`, the console example `dotnet build`, and a `dotnet pack` check for MIT package metadata.
+- Scope: remote branch publication for `chore/repo-finish` (or equivalent application of commit `5655677`) and subsequent merge onto `main`.
+- Current status: the full fix exists locally and is cleanly committed, but it is not present on GitHub because both available write paths are under-scoped for workflow-file publication.
+- Known blockers/open questions: which credential should publish workflow-file changes in this repo; whether the maintainer wants to push the branch directly or cherry-pick commit `5655677` from a higher-scope environment.
+- Most natural next step: publish `chore/repo-finish` using a token/account with workflow-file write permission, then confirm `.github/workflows/ci.yml` and `LICENSE` both exist on `main`.
 
 ### Runtime Hardening & Correctness
 ### [P1_SOON] Decide whether queue-pressure signaling should become a real hosting/runtime signal
@@ -208,6 +191,9 @@ Order note: keep exactly one evidence-ready next execution slice promoted at a t
 ## Completed
 Context note: `Completed` mixes repo history from this preserved worktree, the clean runtime branch, and earlier feature branches; read it as project memory, not as the exact state of the current checkout.
 
+- [x] 2026-04-17: created clean branch `chore/repo-finish` from `commlib-hub/main`, cherry-picked the root publication-policy doc pass, restored `.github/workflows/ci.yml` from the previously validated repo-polish commit history, verified the branch locally with `dotnet restore`, both `Release` test projects, and the console `Release` build, and confirmed GitHub issues `#21` and `#23` are now closed.
+- [x] 2026-04-17: maintainer chose MIT, so `chore/repo-finish` now adds the root `LICENSE`, sets `PackageLicenseExpression` to `MIT` in `Directory.Build.props`, updates the root README/status files accordingly, and verifies the package metadata path with `dotnet pack src/CommLib.Domain/CommLib.Domain.csproj --configuration Release --no-restore -p:PackageVersion=0.1.0-local-mit -o artifacts/pack-mit`.
+- [x] 2026-04-17: chose the current root-file publication policy to keep `AGENT.md`, `CURRENT_PLAN.md`, `TODOS.md`, `CHANGELOG_AGENT.md`, `DECISIONS.md`, and `PROGRESS.md` at the repository root for now as explicitly marked internal development artifacts rather than moving paths that current workflow/automation depends on; updated the root `README.md` plus the main continuity files accordingly, and left `PROGRESS.md` banner normalization deferred behind its existing encoding-cleanup backlog.
 - [x] 2026-04-17: merged PR `#25` (`[codex] integrate outstanding runtime and repo follow-ups`) into `commlib-hub/main`, pruned the remote feature/cleanup branches so only `main` remains, and confirmed that open PRs are now zero; issue/workflow cleanup is still blocked by missing GitHub write scopes.
 - [x] 2026-04-17: upgraded the repo-facing public-release baseline by replacing the root `README.md` with a public-facing overview, adding central package metadata plus packed `README.md` wiring in `Directory.Build.props`, introducing a Windows CI workflow, tightening `.gitignore`, normalizing package/test project descriptions, and clarifying the console example README so it does not overstate reconnect behavior; verified with `dotnet restore commlib-codex-full.sln`, sequential unit/infrastructure test runs, a console build, and `dotnet pack src/CommLib.Domain/CommLib.Domain.csproj`.
 - [x] 2026-04-17: scoped XML documentation generation to the packable library projects under `src/` instead of the entire repo, fixed the remaining live library XML warning gaps in `DeviceSession`, `LengthPrefixedProtocol`, and `ConnectionManager`, and re-verified cleanly with `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore -v minimal`, `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore -v minimal`, `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --no-restore -v minimal`, and `dotnet pack src/CommLib.Domain/CommLib.Domain.csproj --no-restore -p:PackageVersion=0.1.0-local5 -o artifacts/pack -v minimal`.

--- a/TODOS.md
+++ b/TODOS.md
@@ -4,7 +4,7 @@
 > Not part of the public CommLib runtime or package contract.
 
 ## Execution Context
-- Active checkout: `chore/repo-finish` (clean branch created from `commlib-hub/main` to finish the remaining repository-publication cleanup without touching the conflicted local `main` worktree).
+- Active checkout: `chore/repo-finish-publishable` (clean publishable subset branch created from `commlib-hub/main` so the non-workflow repository cleanup can be pushed without touching the conflicted local `main` worktree).
 - Authoritative repository/runtime baseline: `commlib-hub/main`, which now contains the earlier runtime follow-ups plus the later integration batch from PR `#25`.
 - Truth note: remote feature/cleanup branches have already been deleted; the remaining cleanup work is GitHub metadata/permission-related, not branch-integration work.
 - Execution rule: keep new cleanup/product work on fresh branches from `commlib-hub/main`, not on the preserved local integration branch or the divergent local `main`.
@@ -13,21 +13,21 @@
 Order note: keep exactly one evidence-ready next execution slice promoted at a time.
 
 - [ ] Finalize the remaining public-release blockers for the repository root.
-  Scope: publish local branch `chore/repo-finish` so the restored `.github/workflows/ci.yml`, root `LICENSE`, and MIT package metadata reach `main`.
+  Scope: land the already-pushable MIT/root-policy cleanup from `chore/repo-finish-publishable`, then publish the remaining local workflow-restoration branch `chore/repo-finish`.
   Objective: finish the last repository-facing cleanup step after PR `#25` merged the outstanding code/branch work into `main`, the stale GitHub issues were closed, and MIT was chosen.
-  Validation: `.github/workflows/ci.yml` exists on `main`, issues `#21` and `#23` remain closed, root `LICENSE` exists on `main`, and `Directory.Build.props` carries MIT package metadata truthfully.
+  Validation: root `LICENSE` exists on GitHub, `Directory.Build.props` carries MIT package metadata truthfully, issues `#21` and `#23` remain closed, and `.github/workflows/ci.yml` eventually exists on `main`.
 
 ## Deferred Backlog
 ### Repository Release & Hygiene
 ### [P0_NOW] Publish the local workflow-restoration branch with credentials that can update workflow files
-- What remains: push or otherwise publish local branch `chore/repo-finish` so the prepared cleanup commits land on GitHub and restore `.github/workflows/ci.yml`, the MIT `LICENSE`, and MIT package metadata on `main`.
-- Why deferred: the available PAT can push normal refs but rejects workflow-file updates without `workflow` scope, and the GitHub app integration returns `403 Resource not accessible by integration` even for remote branch creation in this repo.
-- Objective: finish the last GitHub-side repository cleanup that is now fully prepared and locally verified.
-- Relevant context: `chore/repo-finish` already contains commit `45892c4` (`docs(repo): clarify internal root file policy`), commit `5655677` (`chore(repo): restore ci publication cleanup`), and the MIT follow-up that adds the root `LICENSE` and `PackageLicenseExpression=MIT`. The branch was verified locally with `dotnet restore`, both `dotnet test` projects in `Release`, the console example `dotnet build`, and a `dotnet pack` check for MIT package metadata.
-- Scope: remote branch publication for `chore/repo-finish` (or equivalent application of commit `5655677`) and subsequent merge onto `main`.
-- Current status: the full fix exists locally and is cleanly committed, but it is not present on GitHub because both available write paths are under-scoped for workflow-file publication.
+- What remains: publish local branch `chore/repo-finish` so the prepared workflow commit lands on GitHub and restores `.github/workflows/ci.yml` on `main`.
+- Why deferred: the available PAT can push normal refs but rejects workflow-file updates without `workflow` scope, and the GitHub app integration returns `403 Resource not accessible by integration` even for remote branch creation in this repo. As a result, this cycle split the pushable non-workflow cleanup into `chore/repo-finish-publishable`.
+- Objective: finish the last GitHub-side repository cleanup that remains after the MIT/license/root-policy cleanup is publishable separately.
+- Relevant context: `chore/repo-finish` already contains commit `45892c4` (`docs(repo): clarify internal root file policy`), commit `5655677` (`chore(repo): restore ci publication cleanup`), and the MIT follow-up that adds the root `LICENSE` and `PackageLicenseExpression=MIT`. `chore/repo-finish-publishable` carries the same repo/license/policy cleanup except for `.github/workflows/ci.yml`, so it can be pushed now while the workflow restoration stays local.
+- Scope: remote publication for the remaining workflow-restoration branch `chore/repo-finish` (or equivalent application of commit `5655677`) and subsequent merge onto `main`.
+- Current status: the MIT license, package metadata, and root-policy cleanup now have a pushable branch, but the workflow-file publication itself is still blocked by credential scope.
 - Known blockers/open questions: which credential should publish workflow-file changes in this repo; whether the maintainer wants to push the branch directly or cherry-pick commit `5655677` from a higher-scope environment.
-- Most natural next step: publish `chore/repo-finish` using a token/account with workflow-file write permission, then confirm `.github/workflows/ci.yml` and `LICENSE` both exist on `main`.
+- Most natural next step: push `chore/repo-finish-publishable`, then publish `chore/repo-finish` using a token/account with workflow-file write permission and confirm `.github/workflows/ci.yml` exists on `main`.
 
 ### Runtime Hardening & Correctness
 ### [P1_SOON] Decide whether queue-pressure signaling should become a real hosting/runtime signal

--- a/docs/current-plan.md
+++ b/docs/current-plan.md
@@ -1,5 +1,8 @@
 # Current Plan
 
+> Internal development continuity file for active repository maintenance.
+> Not part of the public CommLib runtime or package contract.
+
 ## Date
 - 2026-04-17
 
@@ -11,24 +14,26 @@
 - PR `#25` merged the outstanding integration batch into `commlib-hub/main`.
 - Remote feature/cleanup branches have been deleted from `commlib-hub`; only `main` remains on the remote.
 - Open PR count is now zero.
-- The validated `.github/workflows/ci.yml` is still missing from `main` because the available credentials in this environment could not write workflow files.
-- Stale issues `#21` and `#23` are still open only because the available GitHub app/PAT could not update issue state.
+- Issues `#21` and `#23` are now closed because their work is already on `main`.
+- `.github/workflows/ci.yml` is still missing from GitHub `main`, but local branch `chore/repo-finish` restores the validated workflow content and verifies it successfully.
+- Publishing `chore/repo-finish` is still blocked in this environment because `git push` lacks workflow-file scope and the GitHub app integration cannot create/update refs in this repo.
+- MIT has now been chosen and this branch adds the root `LICENSE` file plus `PackageLicenseExpression=MIT`.
 - Root `README.md` is now a public-facing overview with honest contract notes.
 - Package metadata is centralized in `Directory.Build.props`, and `README.md` is packed into NuGet packages.
-- A Windows CI workflow has already been authored and validated locally; it still needs to be restored onto `main`.
+- A Windows CI workflow has already been restored on this branch; it still needs to land on `main`.
 - XML documentation output is enabled only for packable library projects under `src/`, not for tests/examples.
 - The remaining library XML warning gaps were fixed in `DeviceSession`, `LengthPrefixedProtocol`, and `ConnectionManager`.
-- Verification passed with:
-  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --no-restore -v minimal`
-  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --no-restore -v minimal`
-  - `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --no-restore -v minimal`
-  - `dotnet pack src/CommLib.Domain/CommLib.Domain.csproj --no-restore -p:PackageVersion=0.1.0-local5 -o artifacts/pack -v minimal`
-- The repo is not fully publication-ready yet because `LICENSE` is still missing and the internal planning files remain exposed at the repo root.
+- Verification passed on this branch with:
+  - `dotnet restore commlib-codex-full.sln`
+  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --configuration Release --no-restore`
+  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --configuration Release --no-restore`
+  - `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --configuration Release --no-restore`
+  - `dotnet pack src/CommLib.Domain/CommLib.Domain.csproj --configuration Release --no-restore -p:PackageVersion=0.1.0-local-mit -o artifacts/pack-mit`
+- The generated `CommLib.Domain.0.1.0-local-mit.nupkg` contains the expected MIT license expression, readme metadata, and repository metadata.
+- The repo is not fully publication-ready yet because `.github/workflows/ci.yml` is restored only on local branch `chore/repo-finish`.
 
 ## Next Work Unit
-1. Restore `.github/workflows/ci.yml` onto `main` with credentials that can write workflow files.
-2. Close stale issues `#21` and `#23` with credentials that can write issue state.
-3. Return to the remaining publication blockers: choose the root `LICENSE`, decide the root-file policy, and normalize or retire `AGENT.md` if needed.
+1. Publish local branch `chore/repo-finish` with credentials that can update workflow files on GitHub.
 
 ## Not In This Step
 - No new runtime/API hardening

--- a/docs/current-plan.md
+++ b/docs/current-plan.md
@@ -16,7 +16,8 @@
 - Open PR count is now zero.
 - Issues `#21` and `#23` are now closed because their work is already on `main`.
 - `.github/workflows/ci.yml` is still missing from GitHub `main`, but local branch `chore/repo-finish` restores the validated workflow content and verifies it successfully.
-- Publishing `chore/repo-finish` is still blocked in this environment because `git push` lacks workflow-file scope and the GitHub app integration cannot create/update refs in this repo.
+- `chore/repo-finish-publishable` intentionally carries only the non-workflow subset of the repo-publication cleanup so the MIT/license/root-policy changes can still be pushed now.
+- Publishing the full `chore/repo-finish` branch is still blocked in this environment because `git push` lacks workflow-file scope and the GitHub app integration cannot create/update refs in this repo.
 - MIT has now been chosen and this branch adds the root `LICENSE` file plus `PackageLicenseExpression=MIT`.
 - Root `README.md` is now a public-facing overview with honest contract notes.
 - Package metadata is centralized in `Directory.Build.props`, and `README.md` is packed into NuGet packages.
@@ -33,7 +34,7 @@
 - The repo is not fully publication-ready yet because `.github/workflows/ci.yml` is restored only on local branch `chore/repo-finish`.
 
 ## Next Work Unit
-1. Publish local branch `chore/repo-finish` with credentials that can update workflow files on GitHub.
+1. Land the pushable non-workflow cleanup branch, then publish local branch `chore/repo-finish` with credentials that can update workflow files on GitHub.
 
 ## Not In This Step
 - No new runtime/API hardening


### PR DESCRIPTION
﻿## What changed
- add the root `LICENSE` file with the maintainer-selected MIT license
- set `PackageLicenseExpression` to `MIT` in `Directory.Build.props`
- clarify the repository root policy so internal continuity files stay explicitly marked as development artifacts
- update continuity/docs files to record that this branch is the publishable non-workflow subset

## Why
- publish the repository-facing cleanup that is already pushable from the current environment
- keep the remaining `.github/workflows/ci.yml` restoration explicit instead of hiding the workflow permission blocker

## Impact
- GitHub/main can receive the MIT license and truthful package metadata now
- public readers get clearer root-level documentation about which files are internal development artifacts
- the workflow restoration remains on local branch `chore/repo-finish` and still needs a higher-scope credential

## Validation
- this branch is the non-workflow subset of the already-verified `chore/repo-finish` branch
- verified on the source branch with:
  - `dotnet restore commlib-codex-full.sln`
  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --configuration Release --no-restore`
  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --configuration Release --no-restore`
  - `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --configuration Release --no-restore`
  - `dotnet pack src/CommLib.Domain/CommLib.Domain.csproj --configuration Release --no-restore -p:PackageVersion=0.1.0-local-mit -o artifacts/pack-mit`
- no additional code changes were introduced beyond that verified subset
