### PR TITLE
[codex] restore GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore solution
+        run: dotnet restore commlib-codex-full.sln
+
+      - name: Run unit tests
+        run: dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --configuration Release --no-restore
+
+      - name: Run infrastructure tests
+        run: dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --configuration Release --no-restore
+
+      - name: Build console example
+        run: dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --configuration Release --no-restore

--- a/CHANGELOG_AGENT.md
+++ b/CHANGELOG_AGENT.md
@@ -419,6 +419,18 @@
   - created `chore/repo-finish-publishable` from `commlib-hub/main`
   - copied the non-workflow subset from `chore/repo-finish` so MIT license, package metadata, root publication-policy docs, and continuity updates can still be pushed now
   - left `.github/workflows/ci.yml` only on local branch `chore/repo-finish` as the one remaining unpublished blocker
+- Published the non-workflow cleanup subset successfully:
+  - pushed `chore/repo-finish-publishable`
+  - opened draft PR `#26`
+  - marked PR `#26` ready and merged it into `main`
+- Rebased the final workflow restoration onto the updated `main` baseline instead of reviving the wider publication branch:
+  - created the minimal branch `chore/restore-ci-workflow` from `commlib-hub/main`
+  - reapplied only `.github/workflows/ci.yml`
+  - kept the branch to a single workflow-focused commit so the final publish/merge stays narrow
+- This completes the repository-level publication cleanup:
+  - `main` now has MIT license metadata and the root `LICENSE`
+  - root continuity files remain explicitly marked as internal artifacts by policy
+  - the Windows GitHub Actions workflow is restored on `main`
 - Created fresh branch `chore/repo-publication-policy` from `commlib-hub/main` instead of reviving the merged integration branch or the divergent local `main`.
 - Chose the least disruptive root publication policy for now:
   - keep `AGENT.md`, `CURRENT_PLAN.md`, `TODOS.md`, `CHANGELOG_AGENT.md`, `DECISIONS.md`, and `PROGRESS.md` at the repository root

--- a/CURRENT_PLAN.md
+++ b/CURRENT_PLAN.md
@@ -6,25 +6,21 @@
 Date: 2026-04-17
 
 ## Goal
-Raise repository-level public/open-source readiness without changing the core runtime contract in `src/`.
+Resume the highest-priority runtime/application follow-up work from a truthful, publication-ready repository baseline.
 
 ## Confirmed Facts
 - PR `#25` (`[codex] integrate outstanding runtime and repo follow-ups`) is now merged into `commlib-hub/main`.
-- The previously outstanding runtime/messaging/repo-polish slices are now on `main`; only GitHub-side cleanup blockers remain from this integration pass.
+- PR `#26` (`[codex] publish MIT and root policy cleanup`) has already landed on `main`.
 - All remote feature/cleanup branches that were part of the older delivery lines have been deleted from `commlib-hub`; only `main` remains on the remote.
 - GitHub issues `#21` and `#23` are now closed because their work is already present on `main`.
-- `.github/workflows/ci.yml` is still missing from GitHub `main`, but local branch `chore/repo-finish` restores the validated workflow content and verifies it successfully.
-- This branch, `chore/repo-finish-publishable`, intentionally carries only the non-workflow subset of the repo-publication cleanup so it can still be pushed with the currently available credentials.
-- Publishing the full `chore/repo-finish` workflow-restoration branch is still blocked in this environment:
-  - `git push` rejects workflow-file updates because the available PAT lacks `workflow` scope
-  - the GitHub app integration returns `403 Resource not accessible by integration` even for remote branch creation
+- The Windows GitHub Actions workflow `.github/workflows/ci.yml` has now been restored on top of the updated `main` baseline through the dedicated minimal branch `chore/restore-ci-workflow`.
 - The root `README.md` is now a public-facing overview instead of an internal scratch document.
-- The maintainer has now chosen MIT, and this branch adds the root `LICENSE` file plus `PackageLicenseExpression=MIT` in `Directory.Build.props`.
+- The maintainer chose MIT, and `main` now carries the root `LICENSE` file plus `PackageLicenseExpression=MIT` in `Directory.Build.props`.
 - Repository/package polish is now in place:
   - central package metadata lives in `Directory.Build.props`
   - package license metadata now uses `MIT`
   - `README.md` is packed into NuGet packages
-  - `.github/workflows/ci.yml` has been restored on local branch `chore/repo-finish` and still needs to land on `main`
+  - `.github/workflows/ci.yml` is restored on `main`
   - root/test project descriptions were normalized to clean English text
 - XML documentation generation is now scoped to the packable library projects under `src/` rather than the entire repo, which removed test/example warning noise while keeping library documentation output enabled.
 - The remaining library-side XML warnings were fixed in:
@@ -39,18 +35,18 @@ Raise repository-level public/open-source readiness without changing the core ru
 - Verification also confirms the MIT package metadata path:
   - `dotnet pack src/CommLib.Domain/CommLib.Domain.csproj --configuration Release --no-restore -p:PackageVersion=0.1.0-local-mit -o artifacts/pack-mit`
 - The generated `CommLib.Domain.0.1.0-local-mit.nupkg` contains the expected package metadata, including `<license type="expression">MIT</license>`, `<readme>README.md</readme>`, and the repository URL.
-- The repo is closer to public-ready, but it is not fully publication-ready yet because:
-  - `.github/workflows/ci.yml` is restored only on local branch `chore/repo-finish` and still cannot be published from this environment
-  - root internal planning/continuity files now remain by policy as explicitly marked development artifacts
+- The repository-level public/open-source readiness cleanup is complete:
+  - `main` now has the MIT license, truthful package metadata, and the Windows CI workflow
+  - root internal planning/continuity files remain by policy as explicitly marked development artifacts
 
 ## Next Work Unit
-1. Publish the remaining workflow-restoration change from local branch `chore/repo-finish` with a credential that can update workflow files on GitHub after the non-workflow cleanup branch is landed.
+1. Resume the `DeviceSession` internal pending-response cleanup from a fresh branch created from `commlib-hub/main`.
 
 ## Next Slice Design
-1. Keep the next slice at repository/GitHub hygiene scope; do not reopen runtime or WinUI feature work.
-2. Treat the remaining work as publication hygiene only: land the already-pushable MIT/root-policy cleanup first, then publish the prepared workflow-restoration branch with a higher-scope credential.
-3. Do not reopen root-file relocation, runtime cleanup, or WinUI follow-up work in this branch.
+1. Keep the next slice code-local and evidence-ready; do not reopen repository-publication work unless the live GitHub state drifts again.
+2. Start from the already-recorded `DeviceSession` pending-response abstraction cleanup instead of widening immediately into hosting, diagnostics, or WinUI follow-up work.
+3. Continue to branch fresh from `commlib-hub/main`, not from preserved mixed or publication branches.
 
 ## Stop / Reassess Conditions
-- Do not attempt more `git push` or GitHub app branch/file writes for `.github/workflows/ci.yml` from this environment until credentials with workflow-file write capability are available.
+- If new runtime follow-up work starts touching hosting, observability, or public API boundaries more widely than `DeviceSession`, stop and reassess whether the slice should be split.
 - If moving or renaming root internal files would break existing automation or local workflow, stop and document the chosen boundary before editing paths.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -278,3 +278,9 @@
 - Decision: keep `chore/repo-finish` intact as the local source of truth for the validated workflow restoration, but create `chore/repo-finish-publishable` from `commlib-hub/main` and copy only the non-workflow cleanup onto it so the MIT license, package metadata, root-policy docs, and continuity updates can still be pushed immediately.
 - Why: this is the smallest safe way to publish the repo/license cleanup that does not depend on workflow-file write permission, while keeping the still-blocked workflow restoration explicit and reviewable.
 - Consequences: GitHub can receive most of the repo-publication cleanup now, but `.github/workflows/ci.yml` still requires a later publish from `chore/repo-finish` or an equivalent higher-scope cherry-pick.
+
+## 2026-04-17 - Finish the last publication step on a minimal workflow-only branch
+- Context: after PR `#26` merged the MIT/license/root-policy subset into `main`, the only remaining live diff was the missing `.github/workflows/ci.yml`. Keeping the wider `chore/repo-finish` branch as the delivery vehicle would leave already-landed repo/documentation commits mixed back into the final step.
+- Decision: create `chore/restore-ci-workflow` directly from the updated `commlib-hub/main` and carry only the workflow restoration commit there.
+- Why: this keeps the final publication step minimal, reviewable, and easy to reason about while avoiding duplicate repo/doc churn on top of the already-merged `main`.
+- Consequences: once `chore/restore-ci-workflow` lands, repository-level publication cleanup is complete and the next work can return to the previously queued `DeviceSession` internal cleanup.

--- a/README.md
+++ b/README.md
@@ -105,4 +105,3 @@ dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj
 - Treat the runtime behavior in `src/`, package metadata, and the example READMEs as the real product-facing contract.
 - The repository is now licensed under MIT. See [LICENSE](LICENSE).
 - CI currently validates the core libraries, console example, and both test projects on Windows.
-- The remaining publication blocker is still the unpublished workflow-restoration branch that carries `.github/workflows/ci.yml`.

--- a/TODOS.md
+++ b/TODOS.md
@@ -4,31 +4,20 @@
 > Not part of the public CommLib runtime or package contract.
 
 ## Execution Context
-- Active checkout: `chore/repo-finish-publishable` (clean publishable subset branch created from `commlib-hub/main` so the non-workflow repository cleanup can be pushed without touching the conflicted local `main` worktree).
+- Active checkout: `chore/restore-ci-workflow` (dedicated minimal branch created from the updated `commlib-hub/main` baseline to restore the final missing workflow file without reopening the wider repo-publication branch).
 - Authoritative repository/runtime baseline: `commlib-hub/main`, which now contains the earlier runtime follow-ups plus the later integration batch from PR `#25`.
-- Truth note: remote feature/cleanup branches have already been deleted; the remaining cleanup work is GitHub metadata/permission-related, not branch-integration work.
+- Truth note: the repository-level publication cleanup is now complete after MIT/license/root-policy cleanup plus workflow restoration; future work should return to runtime/application follow-ups.
 - Execution rule: keep new cleanup/product work on fresh branches from `commlib-hub/main`, not on the preserved local integration branch or the divergent local `main`.
 
 ## Current TODOs
 Order note: keep exactly one evidence-ready next execution slice promoted at a time.
 
-- [ ] Finalize the remaining public-release blockers for the repository root.
-  Scope: land the already-pushable MIT/root-policy cleanup from `chore/repo-finish-publishable`, then publish the remaining local workflow-restoration branch `chore/repo-finish`.
-  Objective: finish the last repository-facing cleanup step after PR `#25` merged the outstanding code/branch work into `main`, the stale GitHub issues were closed, and MIT was chosen.
-  Validation: root `LICENSE` exists on GitHub, `Directory.Build.props` carries MIT package metadata truthfully, issues `#21` and `#23` remain closed, and `.github/workflows/ci.yml` eventually exists on `main`.
+- [ ] Resume the next evidence-ready runtime cleanup slice.
+  Scope: replace `DeviceSession`'s reflection-based pending-response completion/failure dispatch with a private typed pending-entry abstraction.
+  Objective: improve a hot internal path without widening into hosting, observability, or public API redesign.
+  Validation: focused `DeviceSession` unit coverage still passes and no public contract/documentation truth regresses.
 
 ## Deferred Backlog
-### Repository Release & Hygiene
-### [P0_NOW] Publish the local workflow-restoration branch with credentials that can update workflow files
-- What remains: publish local branch `chore/repo-finish` so the prepared workflow commit lands on GitHub and restores `.github/workflows/ci.yml` on `main`.
-- Why deferred: the available PAT can push normal refs but rejects workflow-file updates without `workflow` scope, and the GitHub app integration returns `403 Resource not accessible by integration` even for remote branch creation in this repo. As a result, this cycle split the pushable non-workflow cleanup into `chore/repo-finish-publishable`.
-- Objective: finish the last GitHub-side repository cleanup that remains after the MIT/license/root-policy cleanup is publishable separately.
-- Relevant context: `chore/repo-finish` already contains commit `45892c4` (`docs(repo): clarify internal root file policy`), commit `5655677` (`chore(repo): restore ci publication cleanup`), and the MIT follow-up that adds the root `LICENSE` and `PackageLicenseExpression=MIT`. `chore/repo-finish-publishable` carries the same repo/license/policy cleanup except for `.github/workflows/ci.yml`, so it can be pushed now while the workflow restoration stays local.
-- Scope: remote publication for the remaining workflow-restoration branch `chore/repo-finish` (or equivalent application of commit `5655677`) and subsequent merge onto `main`.
-- Current status: the MIT license, package metadata, and root-policy cleanup now have a pushable branch, but the workflow-file publication itself is still blocked by credential scope.
-- Known blockers/open questions: which credential should publish workflow-file changes in this repo; whether the maintainer wants to push the branch directly or cherry-pick commit `5655677` from a higher-scope environment.
-- Most natural next step: push `chore/repo-finish-publishable`, then publish `chore/repo-finish` using a token/account with workflow-file write permission and confirm `.github/workflows/ci.yml` exists on `main`.
-
 ### Runtime Hardening & Correctness
 ### [P1_SOON] Decide whether queue-pressure signaling should become a real hosting/runtime signal
 - What remains: decide whether the bounded inbound queue should keep pressure visibility internal-only or whether the hosting/runtime surface should expose queue-pressure events, counters, or diagnostics hooks.
@@ -191,6 +180,7 @@ Order note: keep exactly one evidence-ready next execution slice promoted at a t
 ## Completed
 Context note: `Completed` mixes repo history from this preserved worktree, the clean runtime branch, and earlier feature branches; read it as project memory, not as the exact state of the current checkout.
 
+- [x] 2026-04-17: finished the repository-level publication cleanup by merging PR `#26` for the MIT/license/root-policy subset, then restoring `.github/workflows/ci.yml` from the dedicated minimal branch `chore/restore-ci-workflow` so GitHub `main` now carries the Windows CI workflow too.
 - [x] 2026-04-17: created clean branch `chore/repo-finish` from `commlib-hub/main`, cherry-picked the root publication-policy doc pass, restored `.github/workflows/ci.yml` from the previously validated repo-polish commit history, verified the branch locally with `dotnet restore`, both `Release` test projects, and the console `Release` build, and confirmed GitHub issues `#21` and `#23` are now closed.
 - [x] 2026-04-17: maintainer chose MIT, so `chore/repo-finish` now adds the root `LICENSE`, sets `PackageLicenseExpression` to `MIT` in `Directory.Build.props`, updates the root README/status files accordingly, and verifies the package metadata path with `dotnet pack src/CommLib.Domain/CommLib.Domain.csproj --configuration Release --no-restore -p:PackageVersion=0.1.0-local-mit -o artifacts/pack-mit`.
 - [x] 2026-04-17: chose the current root-file publication policy to keep `AGENT.md`, `CURRENT_PLAN.md`, `TODOS.md`, `CHANGELOG_AGENT.md`, `DECISIONS.md`, and `PROGRESS.md` at the repository root for now as explicitly marked internal development artifacts rather than moving paths that current workflow/automation depends on; updated the root `README.md` plus the main continuity files accordingly, and left `PROGRESS.md` banner normalization deferred behind its existing encoding-cleanup backlog.

--- a/docs/current-plan.md
+++ b/docs/current-plan.md
@@ -7,21 +7,20 @@
 - 2026-04-17
 
 ## Current Scope
-- Finish the repository-level public-ready cleanup without changing the runtime contract in `src/`
-- Keep the work focused on GitHub cleanup, repo-facing docs, package metadata, and publication blockers
+- Resume the next runtime/application follow-up work from a truthful, publication-ready repository baseline
+- Keep the next work focused on a narrow code-local slice rather than more repo-publication cleanup
 
 ## Confirmed State
 - PR `#25` merged the outstanding integration batch into `commlib-hub/main`.
 - Remote feature/cleanup branches have been deleted from `commlib-hub`; only `main` remains on the remote.
 - Open PR count is now zero.
+- PR `#26` merged the MIT/license/root-policy cleanup into `main`.
 - Issues `#21` and `#23` are now closed because their work is already on `main`.
-- `.github/workflows/ci.yml` is still missing from GitHub `main`, but local branch `chore/repo-finish` restores the validated workflow content and verifies it successfully.
-- `chore/repo-finish-publishable` intentionally carries only the non-workflow subset of the repo-publication cleanup so the MIT/license/root-policy changes can still be pushed now.
-- Publishing the full `chore/repo-finish` branch is still blocked in this environment because `git push` lacks workflow-file scope and the GitHub app integration cannot create/update refs in this repo.
+- `.github/workflows/ci.yml` has now been restored on top of the updated `main` baseline through the dedicated minimal branch `chore/restore-ci-workflow`.
 - MIT has now been chosen and this branch adds the root `LICENSE` file plus `PackageLicenseExpression=MIT`.
 - Root `README.md` is now a public-facing overview with honest contract notes.
 - Package metadata is centralized in `Directory.Build.props`, and `README.md` is packed into NuGet packages.
-- A Windows CI workflow has already been restored on this branch; it still needs to land on `main`.
+- A Windows CI workflow is now part of the live `main` branch state.
 - XML documentation output is enabled only for packable library projects under `src/`, not for tests/examples.
 - The remaining library XML warning gaps were fixed in `DeviceSession`, `LengthPrefixedProtocol`, and `ConnectionManager`.
 - Verification passed on this branch with:
@@ -31,10 +30,10 @@
   - `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --configuration Release --no-restore`
   - `dotnet pack src/CommLib.Domain/CommLib.Domain.csproj --configuration Release --no-restore -p:PackageVersion=0.1.0-local-mit -o artifacts/pack-mit`
 - The generated `CommLib.Domain.0.1.0-local-mit.nupkg` contains the expected MIT license expression, readme metadata, and repository metadata.
-- The repo is not fully publication-ready yet because `.github/workflows/ci.yml` is restored only on local branch `chore/repo-finish`.
+- The repository-level public/open-source readiness cleanup is now complete.
 
 ## Next Work Unit
-1. Land the pushable non-workflow cleanup branch, then publish local branch `chore/repo-finish` with credentials that can update workflow files on GitHub.
+1. Resume the `DeviceSession` pending-response abstraction cleanup from a fresh branch off `commlib-hub/main`.
 
 ## Not In This Step
 - No new runtime/API hardening


### PR DESCRIPTION
﻿## What changed
- restore `.github/workflows/ci.yml` on top of the already-updated `main` baseline
- keep the workflow branch minimal by carrying only the workflow restoration plus continuity-file truth updates
- update internal continuity files so the repository-publication cleanup is recorded as complete and the next work unit returns to `DeviceSession` cleanup

## Why
- finish the last remaining repository-publication change after PR `#26` landed the MIT/license/root-policy subset
- restore Windows CI validation on GitHub `main`

## Validation
- the restored workflow content was already validated locally before publication with:
  - `dotnet restore commlib-codex-full.sln`
  - `dotnet test tests/CommLib.Unit.Tests/CommLib.Unit.Tests.csproj --configuration Release --no-restore`
  - `dotnet test tests/CommLib.Infrastructure.Tests/CommLib.Infrastructure.Tests.csproj --configuration Release --no-restore`
  - `dotnet build examples/CommLib.Examples.Console/CommLib.Examples.Console.csproj --configuration Release --no-restore`
- this branch adds no new product-code changes beyond the workflow restoration and continuity sync
